### PR TITLE
feat: added `getMinimumBalanceForRentExemption` with no network call

### DIFF
--- a/.changeset/few-poems-repair.md
+++ b/.changeset/few-poems-repair.md
@@ -1,0 +1,5 @@
+---
+"gill": minor
+---
+
+added a `getMinimumBalanceForRentExemption` function that does not make an rpc call

--- a/packages/gill/src/__tests__/accounts.ts
+++ b/packages/gill/src/__tests__/accounts.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert";
+
+import { getMinimumBalanceForRentExemption } from "../core/accounts";
+
+/**
+ * Note: Each of the values checked against were obtained directly from the
+ * `getMinimumBalanceForRentExemption` RPC call
+ */
+
+describe("getMinimumBalanceForRentExemption", () => {
+  test("default lamports (no extra space)", () => {
+    const lamports = getMinimumBalanceForRentExemption();
+    assert.equal(lamports, 890_880n);
+  });
+  test("0 bytes (explicitly passed)", () => {
+    const lamports = getMinimumBalanceForRentExemption(0);
+    assert.equal(lamports, 890_880n);
+  });
+  test("1 byte of space (as number)", () => {
+    const lamports = getMinimumBalanceForRentExemption(1);
+    assert.equal(lamports, 897_840n);
+  });
+  test("1 byte of space (as bigint)", () => {
+    const lamports = getMinimumBalanceForRentExemption(1n);
+    assert.equal(lamports, 897_840n);
+  });
+  test("50 bytes of space (as number)", () => {
+    const lamports = getMinimumBalanceForRentExemption(50);
+    assert.equal(lamports, 1_238_880n);
+  });
+  test("50 bytes of space (as bigint)", () => {
+    const lamports = getMinimumBalanceForRentExemption(50n);
+    assert.equal(lamports, 1_238_880n);
+  });
+  test("1k bytes of space", () => {
+    const lamports = getMinimumBalanceForRentExemption(1_000);
+    assert.equal(lamports, 7_850_880n);
+  });
+});

--- a/packages/gill/src/core/accounts.ts
+++ b/packages/gill/src/core/accounts.ts
@@ -1,32 +1,34 @@
 /**
- * Default values for Rent calculations
- *
- * Values taken from: https://github.com/anza-xyz/agave/blob/master/sdk/rent/src/lib.rs#L93-L97
- */
-const RENT = {
-  /**
-   * Account storage overhead for calculation of base rent. (aka the number of bytes required to store an account with no data.
-   */
-  ACCOUNT_STORAGE_OVERHEAD: 128n,
-  /**
-   * Amount of time (in years) a balance must include rent for the account to
-   * be rent exempt.
-   */
-  DEFAULT_EXEMPTION_THRESHOLD: BigInt(Math.floor(2.0 * 1000)) / 1000n,
-  /**
-   * Default rental rate in lamports/byte-year. This calculation is based on:
-   * - 10^9 lamports per SOL
-   * - $1 per SOL
-   * - $0.01 per megabyte day
-   * - $3.65 per megabyte year
-   */
-  DEFAULT_LAMPORTS_PER_BYTE_YEAR: BigInt(Math.floor(((1_000_000_000 / 100) * 365) / (1024 * 1024))),
-};
-
-/**
  * Calculate the total rent needed for to create an account, with or without extra data stored in it
  */
 export function getMinimumBalanceForRentExemption(space: bigint | number = 0) {
+  /**
+   * Default values for Rent calculations
+   *
+   * Values taken from: https://github.com/anza-xyz/agave/blob/master/sdk/rent/src/lib.rs#L93-L97
+   */
+  const RENT = {
+    /**
+     * Account storage overhead for calculation of base rent. (aka the number of bytes required to store an account with no data.
+     */
+    ACCOUNT_STORAGE_OVERHEAD: 128n,
+    /**
+     * Amount of time (in years) a balance must include rent for the account to
+     * be rent exempt.
+     */
+    DEFAULT_EXEMPTION_THRESHOLD: BigInt(Math.floor(2.0 * 1000)) / 1000n,
+    /**
+     * Default rental rate in lamports/byte-year. This calculation is based on:
+     * - 10^9 lamports per SOL
+     * - $1 per SOL
+     * - $0.01 per megabyte day
+     * - $3.65 per megabyte year
+     */
+    DEFAULT_LAMPORTS_PER_BYTE_YEAR: BigInt(
+      Math.floor(((1_000_000_000 / 100) * 365) / (1024 * 1024)),
+    ),
+  };
+
   return (
     ((RENT.ACCOUNT_STORAGE_OVERHEAD + BigInt(space)) *
       RENT.DEFAULT_LAMPORTS_PER_BYTE_YEAR *

--- a/packages/gill/src/core/accounts.ts
+++ b/packages/gill/src/core/accounts.ts
@@ -1,0 +1,36 @@
+/**
+ * Default values for Rent calculations
+ *
+ * Values taken from: https://github.com/anza-xyz/agave/blob/master/sdk/rent/src/lib.rs#L93-L97
+ */
+const RENT = {
+  /**
+   * Account storage overhead for calculation of base rent. (aka the number of bytes required to store an account with no data.
+   */
+  ACCOUNT_STORAGE_OVERHEAD: 128n,
+  /**
+   * Amount of time (in years) a balance must include rent for the account to
+   * be rent exempt.
+   */
+  DEFAULT_EXEMPTION_THRESHOLD: BigInt(Math.floor(2.0 * 1000)) / 1000n,
+  /**
+   * Default rental rate in lamports/byte-year. This calculation is based on:
+   * - 10^9 lamports per SOL
+   * - $1 per SOL
+   * - $0.01 per megabyte day
+   * - $3.65 per megabyte year
+   */
+  DEFAULT_LAMPORTS_PER_BYTE_YEAR: BigInt(Math.floor(((1_000_000_000 / 100) * 365) / (1024 * 1024))),
+};
+
+/**
+ * Calculate the total rent needed for to create an account, with or without extra data stored in it
+ */
+export function getMinimumBalanceForRentExemption(space: bigint | number = 0) {
+  return (
+    ((RENT.ACCOUNT_STORAGE_OVERHEAD + BigInt(space)) *
+      RENT.DEFAULT_LAMPORTS_PER_BYTE_YEAR *
+      RENT.DEFAULT_EXEMPTION_THRESHOLD) /
+    1n
+  );
+}

--- a/packages/gill/src/core/index.ts
+++ b/packages/gill/src/core/index.ts
@@ -2,3 +2,4 @@ export * from "./const";
 export * from "./rpc";
 export * from "./explorer";
 export * from "./transactions";
+export * from "./accounts";


### PR DESCRIPTION
### Problem

obtaining the minimum value for rent exception is most commonly obtained from the `getMinimumBalanceForRentExemption` rpc method, which results in a network call and therefore slower

### Summary of Changes

add a sync `getMinimumBalanceForRentExemption` function to perform the math required to calculate the min rent exempt value

Note: there is a trade off here we are making in that IF/WHEN the min rent value is changed or made dynamic, this calculation would become invalid. This should be acceptable for the foreseeable future since this type of change would require a SIMD and have a long rollout time, allowing ample time to adjust this function