### PR TITLE
feat: token clients

### DIFF
--- a/.changeset/perfect-ravens-own.md
+++ b/.changeset/perfect-ravens-own.md
@@ -1,0 +1,5 @@
+---
+"gill": minor
+---
+
+re-export token and token22

--- a/README.md
+++ b/README.md
@@ -189,7 +189,13 @@ To import any of these program clients:
 
 ```typescript
 import { ... } from "gill/programs";
+import { ... } from "gill/programs/token";
+import { ... } from "gill/programs/token22";
 ```
+
+> Note: Some client re-exported client program clients have a naming collision. As a result, they
+> may be re-exported under a subpath of `gill/programs`. For example, `gill/programs/token22` and
+> `gill/programs/token`.
 
 The program clients included inside `gill` are:
 
@@ -198,21 +204,19 @@ The program clients included inside `gill` are:
 - [Compute Budget program](https://github.com/solana-program/compute-budget) - re-exported from
   `@solana-program/compute-budget`
 - [Memo program](https://github.com/solana-program/memo) - re-exported from `@solana-program/memo`
+- [Token program](https://github.com/solana-program/token) - re-exported from
+  `@solana-program/token`
+- [Token Extension program (aka Token22)](https://github.com/solana-program/token-2022) -
+  re-exported from `@solana-program/token-2022`
 
-If one of the existing clients are not being exported from `gill/programs`, you can manually add
-their compatible client to your repo.
+If one of the existing clients are not being exported from `gill/programs` or a subpath therein, you
+can of course manually add their compatible client to your repo.
 
 ### Other compatible program clients
 
 From the [solana-program](https://github.com/solana-program/token) GitHub organization - formerly
 known as the Solana Program Library (SPL)
 
-- [Token program](https://github.com/solana-program/token) - re-exported from
-  `@solana-program/token`
-- [Token Extension program (aka Token22)](https://github.com/solana-program/token-2022) -
-  re-exported from `@solana-program/token-2022`
-- [Associated Token Account program](https://github.com/solana-program/associated-token-account) -
-  re-exported from `@solana-program/associated-token-account`
 - [Stake program](https://github.com/solana-program/stake) - re-exported from
   `@solana-program/stake`
 - [Address Lookup Table program](https://github.com/solana-program/address-lookup-table) -

--- a/packages/gill/README.md
+++ b/packages/gill/README.md
@@ -189,7 +189,13 @@ To import any of these program clients:
 
 ```typescript
 import { ... } from "gill/programs";
+import { ... } from "gill/programs/token";
+import { ... } from "gill/programs/token22";
 ```
+
+> Note: Some client re-exported client program clients have a naming collision. As a result, they
+> may be re-exported under a subpath of `gill/programs`. For example, `gill/programs/token22` and
+> `gill/programs/token`.
 
 The program clients included inside `gill` are:
 
@@ -198,21 +204,19 @@ The program clients included inside `gill` are:
 - [Compute Budget program](https://github.com/solana-program/compute-budget) - re-exported from
   `@solana-program/compute-budget`
 - [Memo program](https://github.com/solana-program/memo) - re-exported from `@solana-program/memo`
+- [Token program](https://github.com/solana-program/token) - re-exported from
+  `@solana-program/token`
+- [Token Extension program (aka Token22)](https://github.com/solana-program/token-2022) -
+  re-exported from `@solana-program/token-2022`
 
-If one of the existing clients are not being exported from `gill/programs`, you can manually add
-their compatible client to your repo.
+If one of the existing clients are not being exported from `gill/programs` or a subpath therein, you
+can of course manually add their compatible client to your repo.
 
 ### Other compatible program clients
 
 From the [solana-program](https://github.com/solana-program/token) GitHub organization - formerly
 known as the Solana Program Library (SPL)
 
-- [Token program](https://github.com/solana-program/token) - re-exported from
-  `@solana-program/token`
-- [Token Extension program (aka Token22)](https://github.com/solana-program/token-2022) -
-  re-exported from `@solana-program/token-2022`
-- [Associated Token Account program](https://github.com/solana-program/associated-token-account) -
-  re-exported from `@solana-program/associated-token-account`
 - [Stake program](https://github.com/solana-program/stake) - re-exported from
   `@solana-program/stake`
 - [Address Lookup Table program](https://github.com/solana-program/address-lookup-table) -

--- a/packages/gill/package.json
+++ b/packages/gill/package.json
@@ -48,6 +48,16 @@
       "import": "./dist/programs/index.node.mjs",
       "require": "./dist/programs/index.node.cjs"
     },
+    "./programs/token": {
+      "types": "./dist/programs/token.d.ts",
+      "import": "./dist/programs/token.node.mjs",
+      "require": "./dist/programs/token.node.cjs"
+    },
+    "./programs/token22": {
+      "types": "./dist/programs/token22.d.ts",
+      "import": "./dist/programs/token22.node.mjs",
+      "require": "./dist/programs/token22.node.cjs"
+    },
     "./types": "./dist/index.d.ts"
   },
   "browser": {
@@ -87,6 +97,8 @@
     "@solana-program/compute-budget": "^0.6.1",
     "@solana-program/memo": "^0.6.1",
     "@solana-program/system": "^0.6.2",
+    "@solana-program/token": "^0.4.1",
+    "@solana-program/token-2022": "^0.3.4",
     "@solana/accounts": "^2.0.0",
     "@solana/addresses": "^2.0.0",
     "@solana/codecs": "^2.0.0",

--- a/packages/gill/src/programs/token.ts
+++ b/packages/gill/src/programs/token.ts
@@ -1,0 +1,8 @@
+/**
+ * Re-export SPL token program
+ *
+ * Note: This is not re-exported from the `./index.ts`
+ * file due to a naming collision with token22 program
+ */
+
+export * from "@solana-program/token";

--- a/packages/gill/src/programs/token22.ts
+++ b/packages/gill/src/programs/token22.ts
@@ -1,0 +1,8 @@
+/**
+ * Re-export SPL token extension program
+ *
+ * Note: This is not re-exported from the `./index.ts`
+ * file due to a naming collision with original token program
+ */
+
+export * from "@solana-program/token-2022";

--- a/packages/gill/tsup.config.package.ts
+++ b/packages/gill/tsup.config.package.ts
@@ -9,14 +9,10 @@ export default defineConfig((options = {}) => [
     entry: {
       index: "src/index.ts",
       "node/index": "src/node/index.ts",
-    },
-  }),
-  // some program clients have symbol collision, so this helps avoid those
-  ...getBaseConfig("node", ["cjs", "esm"], {
-    ...options,
-    entry: {
-      index: "src/programs/index.ts",
+      // some program clients have symbol collision, re-exporting under a different path helps resolve them
       "programs/index": "src/programs/index.ts",
+      "programs/token": "src/programs/token.ts",
+      "programs/token22": "src/programs/token22.ts",
     },
   }),
   ...getBaseConfig("browser", ["cjs", "esm"], options),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,12 @@ importers:
       '@solana-program/system':
         specifier: ^0.6.2
         version: 0.6.2(@solana/web3.js@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))
+      '@solana-program/token':
+        specifier: ^0.4.1
+        version: 0.4.1(@solana/web3.js@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))
+      '@solana-program/token-2022':
+        specifier: ^0.3.4
+        version: 0.3.4(@solana/web3.js@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))
       '@solana/accounts':
         specifier: ^2.0.0
         version: 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
@@ -1127,6 +1133,16 @@ packages:
 
   '@solana-program/system@0.6.2':
     resolution: {integrity: sha512-q0ZnylK+LISjuP2jH5GWV9IJPtpzQctj5KQwij9XCDRSGkcFr2fpqptNnVupTLQiNL6Q4c1OZuG8WBmyFXVXZw==}
+    peerDependencies:
+      '@solana/web3.js': ^2.0.0
+
+  '@solana-program/token-2022@0.3.4':
+    resolution: {integrity: sha512-URHA91F9sDibbL6RbuhnKHWGeAONCDcCmHq8tMtpVOhse9/WKp0JOvdLSiGuRkKZqLHo74xF8otmgPVchgVZXQ==}
+    peerDependencies:
+      '@solana/web3.js': ^2.0.0
+
+  '@solana-program/token@0.4.1':
+    resolution: {integrity: sha512-eSYmjsapzE9jXT2J9xydlMj/zsangMEIZAy9dy75VCXM6kgDCSnH5R7+HsIoKOTvb2VggU7GojC+YhMwWGCIBw==}
     peerDependencies:
       '@solana/web3.js': ^2.0.0
 
@@ -5189,6 +5205,14 @@ snapshots:
       '@solana/web3.js': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
 
   '@solana-program/system@0.6.2(@solana/web3.js@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))':
+    dependencies:
+      '@solana/web3.js': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+
+  '@solana-program/token-2022@0.3.4(@solana/web3.js@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))':
+    dependencies:
+      '@solana/web3.js': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+
+  '@solana-program/token@0.4.1(@solana/web3.js@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/web3.js': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
 


### PR DESCRIPTION
### Summary of Changes

Add the token and token22 clients via a reexport under a `gill/system` subpath (due to naming collisions)