### PR TITLE
get explorer url as string and signed transactions

### DIFF
--- a/.changeset/dull-deers-jam.md
+++ b/.changeset/dull-deers-jam.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+getExplorerUrl to return a string and accepted a signed transaction

--- a/README.md
+++ b/README.md
@@ -103,12 +103,19 @@ Craft a Solana Explorer link for transactions, accounts, or blocks on any cluste
 
 > When no `cluster` is provided, defaults to `mainnet`.
 
+To get an explorer link for a transaction (from its signatured or a signed transaction object):
+
 ```typescript
 import { getExplorerLink } from "gill";
 
-const link: URL = getExplorerLink({
+const link: string = getExplorerLink({
   transaction:
     "4nzNU7YxPtPsVzeg16oaZvLz4jMPtbAzavDfEFmemHNv93iYXKKYAaqBJzFCwEVxiULqTYYrbjPwQnA1d9ZCTELg",
+});
+
+let signedTransaction = await signTransactionMessageWithSigners(...);
+const link2: string = getExplorerLink({
+  transaction: signedTransaction,
 });
 ```
 
@@ -117,7 +124,7 @@ To get an explorer link for an account on Solana's devnet:
 ```typescript
 import { getExplorerLink } from "gill";
 
-const link: URL = getExplorerLink({
+const link: string = getExplorerLink({
   cluster: "devnet",
   account: "nick6zJc6HpW3kfBm4xS2dmbuVRyb5F3AnUvj5ymzR5",
 });
@@ -128,7 +135,7 @@ To get an explorer link for an account on your local test validator:
 ```typescript
 import { getExplorerLink } from "gill";
 
-const link: URL = getExplorerLink({
+const link: string = getExplorerLink({
   cluster: "localnet",
   account: "11111111111111111111111111111111",
 });
@@ -139,7 +146,7 @@ To get an explorer link for a block:
 ```typescript
 import { getExplorerLink } from "gill";
 
-const link: URL = getExplorerLink({
+const link: string = getExplorerLink({
   cluster: "mainnet",
   block: "242233124",
 });

--- a/packages/gill/README.md
+++ b/packages/gill/README.md
@@ -103,12 +103,19 @@ Craft a Solana Explorer link for transactions, accounts, or blocks on any cluste
 
 > When no `cluster` is provided, defaults to `mainnet`.
 
+To get an explorer link for a transaction (from its signatured or a signed transaction object):
+
 ```typescript
 import { getExplorerLink } from "gill";
 
-const link: URL = getExplorerLink({
+const link: string = getExplorerLink({
   transaction:
     "4nzNU7YxPtPsVzeg16oaZvLz4jMPtbAzavDfEFmemHNv93iYXKKYAaqBJzFCwEVxiULqTYYrbjPwQnA1d9ZCTELg",
+});
+
+let signedTransaction = await signTransactionMessageWithSigners(...);
+const link2: string = getExplorerLink({
+  transaction: signedTransaction,
 });
 ```
 
@@ -117,7 +124,7 @@ To get an explorer link for an account on Solana's devnet:
 ```typescript
 import { getExplorerLink } from "gill";
 
-const link: URL = getExplorerLink({
+const link: string = getExplorerLink({
   cluster: "devnet",
   account: "nick6zJc6HpW3kfBm4xS2dmbuVRyb5F3AnUvj5ymzR5",
 });
@@ -128,7 +135,7 @@ To get an explorer link for an account on your local test validator:
 ```typescript
 import { getExplorerLink } from "gill";
 
-const link: URL = getExplorerLink({
+const link: string = getExplorerLink({
   cluster: "localnet",
   account: "11111111111111111111111111111111",
 });
@@ -139,7 +146,7 @@ To get an explorer link for a block:
 ```typescript
 import { getExplorerLink } from "gill";
 
-const link: URL = getExplorerLink({
+const link: string = getExplorerLink({
   cluster: "mainnet",
   block: "242233124",
 });

--- a/packages/gill/src/__tests__/explorer.ts
+++ b/packages/gill/src/__tests__/explorer.ts
@@ -1,12 +1,13 @@
 import assert from "node:assert";
+import { FullySignedTransaction } from "@solana/transactions";
 
-import { getExplorerLink } from "../../src/index";
+import { getExplorerLink } from "../../src/core/explorer";
 
 describe("getExplorerLink", () => {
   test("getExplorerLink works for a block on mainnet when no network is supplied", () => {
     const link = getExplorerLink({
       block: "242233124",
-    }).toString();
+    });
     assert.equal(link, "https://explorer.solana.com/block/242233124");
   });
 
@@ -14,7 +15,7 @@ describe("getExplorerLink", () => {
     const link = getExplorerLink({
       cluster: "mainnet-beta",
       block: "242233124",
-    }).toString();
+    });
     assert.equal(link, "https://explorer.solana.com/block/242233124");
   });
 
@@ -22,7 +23,7 @@ describe("getExplorerLink", () => {
     const link = getExplorerLink({
       cluster: "mainnet",
       block: "242233124",
-    }).toString();
+    });
     assert.equal(link, "https://explorer.solana.com/block/242233124");
   });
 
@@ -30,7 +31,7 @@ describe("getExplorerLink", () => {
     const link = getExplorerLink({
       cluster: "mainnet-beta",
       address: "dDCQNnDmNbFVi8cQhKAgXhyhXeJ625tvwsunRyRc7c8",
-    }).toString();
+    });
     assert.equal(
       link,
       "https://explorer.solana.com/address/dDCQNnDmNbFVi8cQhKAgXhyhXeJ625tvwsunRyRc7c8",
@@ -41,10 +42,42 @@ describe("getExplorerLink", () => {
     const link = getExplorerLink({
       cluster: "devnet",
       address: "dDCQNnDmNbFVi8cQhKAgXhyhXeJ625tvwsunRyRc7c8",
-    }).toString();
+    });
     assert.equal(
       link,
       "https://explorer.solana.com/address/dDCQNnDmNbFVi8cQhKAgXhyhXeJ625tvwsunRyRc7c8?cluster=devnet",
+    );
+  });
+
+  test("getExplorerLink works for a transaction signature", () => {
+    const link = getExplorerLink({
+      transaction:
+        "2YhzivV92fw9oT6RjTBWSdqR8Sc9FTWxzPMwAzeqiWutXfEgiwhXz3iCnayt9P8nmKwwGn2wDYsGRCSdeoxTJCDX",
+    });
+    assert.equal(
+      link,
+      "https://explorer.solana.com/tx/2YhzivV92fw9oT6RjTBWSdqR8Sc9FTWxzPMwAzeqiWutXfEgiwhXz3iCnayt9P8nmKwwGn2wDYsGRCSdeoxTJCDX",
+    );
+  });
+
+  test("getExplorerLink works for a signed transaction", () => {
+    const signedTx = {
+      signatures: {
+        nicktrLHhYzLmoVbuZQzHUTicd2sfP571orwo9jfc8c: [
+          77, 92, 24, 170, 25, 33, 200, 153, 230, 77, 49, 85, 252, 160, 42, 192, 68, 242, 160, 20,
+          64, 71, 154, 190, 6, 63, 124, 101, 224, 127, 147, 238, 138, 252, 144, 23, 49, 97, 73, 118,
+          118, 94, 32, 147, 76, 228, 241, 244, 182, 223, 244, 135, 175, 158, 129, 227, 23, 49, 177,
+          159, 227, 46, 23, 10,
+        ],
+      },
+    } as unknown as FullySignedTransaction;
+
+    const link = getExplorerLink({
+      transaction: signedTx,
+    });
+    assert.equal(
+      link,
+      "https://explorer.solana.com/tx/2YhzivV92fw9oT6RjTBWSdqR8Sc9FTWxzPMwAzeqiWutXfEgiwhXz3iCnayt9P8nmKwwGn2wDYsGRCSdeoxTJCDX",
     );
   });
 
@@ -52,11 +85,11 @@ describe("getExplorerLink", () => {
     const link = getExplorerLink({
       cluster: "devnet",
       transaction:
-        "4nzNU7YxPtPsVzeg16oaZvLz4jMPtbAzavDfEFmemHNv93iYXKKYAaqBJzFCwEVxiULqTYYrbjPwQnA1d9ZCTELg",
-    }).toString();
+        "2YhzivV92fw9oT6RjTBWSdqR8Sc9FTWxzPMwAzeqiWutXfEgiwhXz3iCnayt9P8nmKwwGn2wDYsGRCSdeoxTJCDX",
+    });
     assert.equal(
       link,
-      "https://explorer.solana.com/tx/4nzNU7YxPtPsVzeg16oaZvLz4jMPtbAzavDfEFmemHNv93iYXKKYAaqBJzFCwEVxiULqTYYrbjPwQnA1d9ZCTELg?cluster=devnet",
+      "https://explorer.solana.com/tx/2YhzivV92fw9oT6RjTBWSdqR8Sc9FTWxzPMwAzeqiWutXfEgiwhXz3iCnayt9P8nmKwwGn2wDYsGRCSdeoxTJCDX?cluster=devnet",
     );
   });
 
@@ -65,7 +98,7 @@ describe("getExplorerLink", () => {
       cluster: "localnet",
       transaction:
         "2QC8BkDVZgaPHUXG9HuPw7aE5d6kN5DTRXLe2inT1NzurkYTCFhraSEo883CPNe18BZ2peJC1x1nojZ5Jmhs94pL",
-    }).toString();
+    });
     assert.equal(
       link,
       "https://explorer.solana.com/tx/2QC8BkDVZgaPHUXG9HuPw7aE5d6kN5DTRXLe2inT1NzurkYTCFhraSEo883CPNe18BZ2peJC1x1nojZ5Jmhs94pL?cluster=custom&customUrl=http%3A%2F%2Flocalhost%3A8899",

--- a/packages/gill/src/core/explorer.ts
+++ b/packages/gill/src/core/explorer.ts
@@ -1,9 +1,10 @@
 import { GetExplorerLinkArgs } from "../types";
+import { getSignatureFromTransaction } from "@solana/transactions";
 
 /**
  * Craft a Solana Explorer link on any cluster
  */
-export function getExplorerLink(props: GetExplorerLinkArgs): URL {
+export function getExplorerLink(props: GetExplorerLinkArgs): string {
   let url: URL | null = null;
 
   // default to mainnet / mainnet-beta
@@ -12,7 +13,13 @@ export function getExplorerLink(props: GetExplorerLinkArgs): URL {
   if ("address" in props) {
     url = new URL(`https://explorer.solana.com/address/${props.address}`);
   } else if ("transaction" in props) {
-    url = new URL(`https://explorer.solana.com/tx/${props.transaction}`);
+    if (typeof props.transaction == "string") {
+      url = new URL(`https://explorer.solana.com/tx/${props.transaction}`);
+    } else {
+      url = new URL(
+        `https://explorer.solana.com/tx/${getSignatureFromTransaction(props.transaction)}`,
+      );
+    }
   } else if ("block" in props) {
     url = new URL(`https://explorer.solana.com/block/${props.block}`);
   }
@@ -29,5 +36,5 @@ export function getExplorerLink(props: GetExplorerLinkArgs): URL {
     }
   }
 
-  return url;
+  return url.toString();
 }

--- a/packages/gill/src/types/explorer.ts
+++ b/packages/gill/src/types/explorer.ts
@@ -1,10 +1,11 @@
+import { FullySignedTransaction } from "@solana/transactions";
 import { SolanaClusterMoniker } from "./rpc";
 
 type ExplorerLinkAccount = {
   address: string;
 };
 type ExplorerLinkTransaction = {
-  transaction: string;
+  transaction: string | FullySignedTransaction;
 };
 type ExplorerLinkBlock = {
   block: string;


### PR DESCRIPTION
### Summary of Changes

- make `getExplorerUrl` return a string vice URL
- accept a signed transaction in addition to a transaction signature