### PR TITLE
refactor: explorer link

### DIFF
--- a/.changeset/weak-yaks-joke.md
+++ b/.changeset/weak-yaks-joke.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+refactor getExplorerLink to not accept a signed transaction

--- a/packages/gill/src/__tests__/explorer.ts
+++ b/packages/gill/src/__tests__/explorer.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { FullySignedTransaction } from "@solana/transactions";
+import { FullySignedTransaction, getSignatureFromTransaction } from "@solana/transactions";
 
 import { getExplorerLink } from "../../src/core/explorer";
 
@@ -72,8 +72,14 @@ describe("getExplorerLink", () => {
       },
     } as unknown as FullySignedTransaction;
 
+    const signature = getSignatureFromTransaction(signedTx);
+    assert.equal(
+      signature,
+      "2YhzivV92fw9oT6RjTBWSdqR8Sc9FTWxzPMwAzeqiWutXfEgiwhXz3iCnayt9P8nmKwwGn2wDYsGRCSdeoxTJCDX",
+    );
+
     const link = getExplorerLink({
-      transaction: signedTx,
+      transaction: signature,
     });
     assert.equal(
       link,

--- a/packages/gill/src/core/explorer.ts
+++ b/packages/gill/src/core/explorer.ts
@@ -1,5 +1,4 @@
 import { GetExplorerLinkArgs } from "../types";
-import { getSignatureFromTransaction } from "@solana/transactions";
 
 /**
  * Craft a Solana Explorer link on any cluster
@@ -13,13 +12,7 @@ export function getExplorerLink(props: GetExplorerLinkArgs): string {
   if ("address" in props) {
     url = new URL(`https://explorer.solana.com/address/${props.address}`);
   } else if ("transaction" in props) {
-    if (typeof props.transaction == "string") {
-      url = new URL(`https://explorer.solana.com/tx/${props.transaction}`);
-    } else {
-      url = new URL(
-        `https://explorer.solana.com/tx/${getSignatureFromTransaction(props.transaction)}`,
-      );
-    }
+    url = new URL(`https://explorer.solana.com/tx/${props.transaction}`);
   } else if ("block" in props) {
     url = new URL(`https://explorer.solana.com/block/${props.block}`);
   }

--- a/packages/gill/src/types/explorer.ts
+++ b/packages/gill/src/types/explorer.ts
@@ -1,11 +1,10 @@
-import { FullySignedTransaction } from "@solana/transactions";
 import { SolanaClusterMoniker } from "./rpc";
 
 type ExplorerLinkAccount = {
   address: string;
 };
 type ExplorerLinkTransaction = {
-  transaction: string | FullySignedTransaction;
+  transaction: string;
 };
 type ExplorerLinkBlock = {
   block: string;


### PR DESCRIPTION
### Summary of Changes

- improved the readme for explorer link and getting signatures
- simplified the `getExplorerLink` function to not accept a signed transaction (better tree shaking!)