### PR TITLE
feat: added base64 transaction helper

### DIFF
--- a/.changeset/green-rats-clap.md
+++ b/.changeset/green-rats-clap.md
@@ -1,0 +1,5 @@
+---
+"gill": minor
+---
+
+added `transactionToBase64` function

--- a/packages/gill/src/__tests__/base64-transactions.ts
+++ b/packages/gill/src/__tests__/base64-transactions.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert";
+
+import { blockhash } from "@solana/rpc-types";
+
+import { address } from "@solana/addresses";
+import { createTransaction } from "../core/transactions";
+import { transactionToBase64 } from "../core/base64-transactions";
+
+// initialize a sample transaction
+const tx = createTransaction({
+  version: "legacy",
+  feePayer: address("nicktrLHhYzLmoVbuZQzHUTicd2sfP571orwo9jfc8c"),
+  instructions: [],
+  latestBlockhash: {
+    blockhash: blockhash("GK1nopeF3P8J46dGqq4KfaEWopZU7K65F6CKQXuUdr3z"),
+    lastValidBlockHeight: 0n,
+  },
+});
+
+describe("transactionToBase64", () => {
+  test("can base64 encode an unsigned transaction", () => {
+    const expected =
+      "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAABC7YxPJkVXZH3qqq8Nq1nwYa5Pm6+M9ZeObND0CCtBLXjfKbGfbEEIU1AEH81ttgpyiNLO+xurYCsjdCVcfR4YQA=";
+
+    assert.equal(expected, transactionToBase64(tx));
+  });
+});

--- a/packages/gill/src/core/base64-transactions.ts
+++ b/packages/gill/src/core/base64-transactions.ts
@@ -1,0 +1,22 @@
+import { pipe } from "@solana/functional";
+import { CompilableTransactionMessage } from "@solana/transaction-messages";
+
+import {
+  Transaction,
+  compileTransaction,
+  Base64EncodedWireTransaction,
+  getBase64EncodedWireTransaction,
+} from "@solana/transactions";
+
+/**
+ * Compile a Transaction to a base64 string
+ */
+export function transactionToBase64(
+  tx: CompilableTransactionMessage | Transaction,
+): Base64EncodedWireTransaction {
+  if ("messageBytes" in tx) {
+    return pipe(tx, getBase64EncodedWireTransaction);
+  } else {
+    return pipe(tx, compileTransaction, getBase64EncodedWireTransaction);
+  }
+}

--- a/packages/gill/src/core/index.ts
+++ b/packages/gill/src/core/index.ts
@@ -2,4 +2,5 @@ export * from "./const";
 export * from "./rpc";
 export * from "./explorer";
 export * from "./transactions";
+export * from "./base64-transactions";
 export * from "./accounts";


### PR DESCRIPTION
### Summary of Changes

added the `transactionToBase64` function to easily compile a transaction to a base64 string