### PR TITLE
Sending transactions

### DIFF
--- a/.changeset/polite-goats-poke.md
+++ b/.changeset/polite-goats-poke.md
@@ -1,0 +1,5 @@
+---
+"gill": minor
+---
+
+added `sendAndConfirmTransaction` to the client creator

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ yarn add gill
 - [Create a Solana RPC connection](#create-a-solana-rpc-connection)
 - [Create a transaction](#create-a-transaction)
 - [Signing transactions](#signing-transactions)
+- [Sending and confirming transaction](#sending-and-confirming-transactions)
 - [Get a transaction signature](#get-the-signature-from-a-signed-transaction)
 - [Get a Solana Explorer link](#get-a-solana-explorer-link-for-transactions-accounts-or-blocks)
 
@@ -39,7 +40,7 @@ moniker (i.e. `devnet`, `localnet`, `mainnet` etc).
 ```typescript
 import { createSolanaClient } from "gill";
 
-const { rpc, rpcSubscriptions } = createSolanaClient({
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient({
   urlOrMoniker: "mainnet",
 });
 ```
@@ -53,7 +54,7 @@ To create an RPC client for your local test validator:
 ```typescript
 import { createSolanaClient } from "gill";
 
-const { rpc, rpcSubscriptions } = createSolanaClient({
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient({
   urlOrMoniker: "localnet",
 });
 ```
@@ -63,7 +64,7 @@ To create an RPC client for an custom RPC provider or service:
 ```typescript
 import { createSolanaClient } from "gill";
 
-const { rpc, rpcSubscriptions } = createSolanaClient({
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient({
   urlOrMoniker: "https://private-solana-rpc-provider.com",
 });
 ```
@@ -126,6 +127,39 @@ const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 const signedTransaction = await signTransactionMessageWithSigners(
   setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
 );
+```
+
+### Sending and confirming transactions
+
+To send and confirm a transaction to the blockchain, you can use the `sendAndConfirmTransaction`
+function initialized from `createSolanaClient`.
+
+```typescript
+import { createSolanaClient, createTransaction, signTransactionMessageWithSigners } from "gill";
+
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient({
+  urlOrMoniker: "mainnet",
+});
+
+const transaction = createTransaction(...);
+
+const signedTransaction = await signTransactionMessageWithSigners(transaction);
+const signature: string = getSignatureFromTransaction(signedTransaction);
+
+// default commitment level of `confirmed`
+await sendAndConfirmTransaction(signedTransaction)
+```
+
+If you would like more fine grain control over the configuration of the `sendAndConfirmTransaction`
+functionality, you can include configuration settings:
+
+```typescript
+await sendAndConfirmTransaction(signedTransaction, {
+  commitment: "confirmed",
+  skipPreflight: true,
+  maxRetries: 10n,
+  ...
+});
 ```
 
 ### Get the signature from a signed transaction

--- a/packages/gill/README.md
+++ b/packages/gill/README.md
@@ -24,6 +24,7 @@ yarn add gill
 - [Create a Solana RPC connection](#create-a-solana-rpc-connection)
 - [Create a transaction](#create-a-transaction)
 - [Signing transactions](#signing-transactions)
+- [Sending and confirming transaction](#sending-and-confirming-transactions)
 - [Get a transaction signature](#get-the-signature-from-a-signed-transaction)
 - [Get a Solana Explorer link](#get-a-solana-explorer-link-for-transactions-accounts-or-blocks)
 
@@ -39,7 +40,7 @@ moniker (i.e. `devnet`, `localnet`, `mainnet` etc).
 ```typescript
 import { createSolanaClient } from "gill";
 
-const { rpc, rpcSubscriptions } = createSolanaClient({
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient({
   urlOrMoniker: "mainnet",
 });
 ```
@@ -53,7 +54,7 @@ To create an RPC client for your local test validator:
 ```typescript
 import { createSolanaClient } from "gill";
 
-const { rpc, rpcSubscriptions } = createSolanaClient({
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient({
   urlOrMoniker: "localnet",
 });
 ```
@@ -63,7 +64,7 @@ To create an RPC client for an custom RPC provider or service:
 ```typescript
 import { createSolanaClient } from "gill";
 
-const { rpc, rpcSubscriptions } = createSolanaClient({
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient({
   urlOrMoniker: "https://private-solana-rpc-provider.com",
 });
 ```
@@ -126,6 +127,39 @@ const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 const signedTransaction = await signTransactionMessageWithSigners(
   setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
 );
+```
+
+### Sending and confirming transactions
+
+To send and confirm a transaction to the blockchain, you can use the `sendAndConfirmTransaction`
+function initialized from `createSolanaClient`.
+
+```typescript
+import { createSolanaClient, createTransaction, signTransactionMessageWithSigners } from "gill";
+
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient({
+  urlOrMoniker: "mainnet",
+});
+
+const transaction = createTransaction(...);
+
+const signedTransaction = await signTransactionMessageWithSigners(transaction);
+const signature: string = getSignatureFromTransaction(signedTransaction);
+
+// default commitment level of `confirmed`
+await sendAndConfirmTransaction(signedTransaction)
+```
+
+If you would like more fine grain control over the configuration of the `sendAndConfirmTransaction`
+functionality, you can include configuration settings:
+
+```typescript
+await sendAndConfirmTransaction(signedTransaction, {
+  commitment: "confirmed",
+  skipPreflight: true,
+  maxRetries: 10n,
+  ...
+});
 ```
 
 ### Get the signature from a signed transaction

--- a/packages/gill/src/__typetests__/rpc.ts
+++ b/packages/gill/src/__typetests__/rpc.ts
@@ -10,12 +10,18 @@ import {
   SolanaRpcApiMainnet,
 } from "@solana/rpc";
 import { createSolanaClient } from "../core/rpc";
+import {
+  sendAndConfirmDurableNonceTransactionFactory,
+  sendAndConfirmTransactionFactory,
+} from "../kit";
 
 // [DESCRIBE] createSolanaClient
 {
   // Mainnet cluster typechecks when the providing the moniker
   {
-    const { rpc: mainnetRpc } = createSolanaClient({ urlOrMoniker: "mainnet" });
+    const { rpc: mainnetRpc, rpcSubscriptions: mainnetRpcSubscriptions } = createSolanaClient({
+      urlOrMoniker: "mainnet",
+    });
     mainnetRpc satisfies Rpc<SolanaRpcApiMainnet>;
     mainnetRpc satisfies RpcMainnet<SolanaRpcApiMainnet>;
     //@ts-expect-error Should not have `requestAirdrop` method
@@ -24,11 +30,22 @@ import { createSolanaClient } from "../core/rpc";
     mainnetRpc satisfies RpcDevnet<SolanaRpcApi>;
     //@ts-expect-error Should not be a testnet RPC
     mainnetRpc satisfies RpcTestnet<SolanaRpcApi>;
+
+    sendAndConfirmTransactionFactory({
+      rpc: mainnetRpc,
+      rpcSubscriptions: mainnetRpcSubscriptions,
+    });
+    sendAndConfirmDurableNonceTransactionFactory({
+      rpc: mainnetRpc,
+      rpcSubscriptions: mainnetRpcSubscriptions,
+    });
   }
 
   // Devnet cluster typechecks when the providing the moniker
   {
-    const { rpc: devnetRpc } = createSolanaClient({ urlOrMoniker: "devnet" });
+    const { rpc: devnetRpc, rpcSubscriptions: devnetRpcSubscriptions } = createSolanaClient({
+      urlOrMoniker: "devnet",
+    });
     devnetRpc satisfies Rpc<SolanaRpcApi>;
     devnetRpc satisfies Rpc<RequestAirdropApi>;
     devnetRpc satisfies RpcDevnet<SolanaRpcApi>;
@@ -36,11 +53,22 @@ import { createSolanaClient } from "../core/rpc";
     devnetRpc satisfies RpcTestnet<SolanaRpcApi>;
     //@ts-expect-error Should not be a mainnet RPC
     devnetRpc satisfies RpcMainnet<SolanaRpcApiMainnet>;
+
+    sendAndConfirmTransactionFactory({
+      rpc: devnetRpc,
+      rpcSubscriptions: devnetRpcSubscriptions,
+    });
+    sendAndConfirmDurableNonceTransactionFactory({
+      rpc: devnetRpc,
+      rpcSubscriptions: devnetRpcSubscriptions,
+    });
   }
 
   // Testnet cluster typechecks when the providing the moniker
   {
-    const { rpc: testnetRpc } = createSolanaClient({ urlOrMoniker: "testnet" });
+    const { rpc: testnetRpc, rpcSubscriptions: testnetRpcSubscriptions } = createSolanaClient({
+      urlOrMoniker: "testnet",
+    });
     testnetRpc satisfies Rpc<SolanaRpcApi>;
     testnetRpc satisfies Rpc<RequestAirdropApi>;
     testnetRpc satisfies RpcTestnet<SolanaRpcApi>;
@@ -48,11 +76,22 @@ import { createSolanaClient } from "../core/rpc";
     testnetRpc satisfies RpcDevnet<SolanaRpcApi>;
     //@ts-expect-error Should not be a mainnet RPC
     testnetRpc satisfies RpcMainnet<SolanaRpcApiMainnet>;
+
+    sendAndConfirmTransactionFactory({
+      rpc: testnetRpc,
+      rpcSubscriptions: testnetRpcSubscriptions,
+    });
+    sendAndConfirmDurableNonceTransactionFactory({
+      rpc: testnetRpc,
+      rpcSubscriptions: testnetRpcSubscriptions,
+    });
   }
 
   // Localnet cluster typechecks when the providing the moniker
   {
-    const { rpc: localnetRpc } = createSolanaClient({ urlOrMoniker: "localnet" });
+    const { rpc: localnetRpc /*rpcSubscriptions: localnetRpcSubscriptions*/ } = createSolanaClient({
+      urlOrMoniker: "localnet",
+    });
     localnetRpc satisfies Rpc<SolanaRpcApi>;
     localnetRpc satisfies Rpc<RequestAirdropApi>;
     //@ts-expect-error Should not be a testnet RPC
@@ -61,11 +100,22 @@ import { createSolanaClient } from "../core/rpc";
     localnetRpc satisfies RpcDevnet<SolanaRpcApi>;
     //@ts-expect-error Should not be a mainnet RPC
     localnetRpc satisfies RpcMainnet<SolanaRpcApiMainnet>;
+
+    // sendAndConfirmTransactionFactory({
+    //   rpc: localnetRpc,
+    //   rpcSubscriptions: localnetRpcSubscriptions,
+    // });
+    // sendAndConfirmDurableNonceTransactionFactory({
+    //   rpc: localnetRpc,
+    //   rpcSubscriptions: localnetRpcSubscriptions,
+    // });
   }
 
   // Localnet cluster typechecks when the providing the moniker
   {
-    const { rpc: genericRpc } = createSolanaClient({ urlOrMoniker: "https://example-rpc.com" });
+    const { rpc: genericRpc, rpcSubscriptions: genericRpcSubscriptions } = createSolanaClient({
+      urlOrMoniker: "https://example-rpc.com",
+    });
     genericRpc satisfies Rpc<SolanaRpcApi>;
     genericRpc satisfies Rpc<RequestAirdropApi>;
     //@ts-expect-error Should not be a testnet RPC
@@ -74,5 +124,14 @@ import { createSolanaClient } from "../core/rpc";
     genericRpc satisfies RpcDevnet<SolanaRpcApi>;
     //@ts-expect-error Should not be a mainnet RPC
     genericRpc satisfies RpcMainnet<SolanaRpcApiMainnet>;
+
+    sendAndConfirmTransactionFactory({
+      rpc: genericRpc,
+      rpcSubscriptions: genericRpcSubscriptions,
+    });
+    sendAndConfirmDurableNonceTransactionFactory({
+      rpc: genericRpc,
+      rpcSubscriptions: genericRpcSubscriptions,
+    });
   }
 }

--- a/packages/gill/src/core/index.ts
+++ b/packages/gill/src/core/index.ts
@@ -4,4 +4,6 @@ export * from "./rpc";
 export * from "./explorer";
 export * from "./transactions";
 export * from "./base64-transactions";
+export * from "./send-and-confirm-transaction";
+export * from "./prepare-transaction";
 export * from "./accounts";

--- a/packages/gill/src/core/prepare-transaction.ts
+++ b/packages/gill/src/core/prepare-transaction.ts
@@ -1,0 +1,104 @@
+import {
+  COMPUTE_BUDGET_PROGRAM_ADDRESS,
+  getSetComputeUnitLimitInstruction,
+} from "@solana-program/compute-budget";
+import {
+  type CompilableTransactionMessage,
+  appendTransactionMessageInstruction,
+  setTransactionMessageLifetimeUsingBlockhash,
+} from "@solana/transaction-messages";
+import type { GetLatestBlockhashApi, Rpc, SimulateTransactionApi } from "@solana/rpc";
+import { isSetComputeLimitInstruction } from "../programs/compute-budget";
+import { getComputeUnitEstimateForTransactionMessageFactory } from "../kit";
+import { debug } from "./debug";
+import { transactionToBase64 } from "./base64-transactions";
+
+export type PrepareTransactionConfig = {
+  /**
+   * RPC client capable of simulating transactions and getting the latest blockhash
+   **/
+  rpc: Rpc<SimulateTransactionApi & GetLatestBlockhashApi>;
+  /**
+   * Multiplier applied to the simulated compute unit value obtained
+   *
+   * Default: `1.1`
+   **/
+  computeUnitLimitMultiplier?: number;
+  /**
+   * Whether or not you wish to force reset the compute unit limit value (if any is set)
+   * using the simulation response and `computeUnitLimitMultiplier`
+   **/
+  computeUnitLimitReset?: boolean;
+  /**
+   * Whether or not you wish to force reset the latest blockhash (if any is set)
+   *
+   * Default: `true`
+   **/
+  blockhashReset?: boolean;
+};
+
+/**
+ * Prepare a Transaction to be signed and sent to the network. Including:
+ * - setting a compute unit limit (if not already set)
+ * - simulating and resetting (if desired)
+ * - fetching the latest blockhash (if not already set)
+ * - resetting latest blockhash to the most recent (if desired)
+ */
+export async function prepareTransaction<
+  TMessage extends CompilableTransactionMessage = CompilableTransactionMessage,
+>(transaction: TMessage, config: PrepareTransactionConfig) {
+  // set the config defaults
+  if (!config.computeUnitLimitMultiplier) config.computeUnitLimitMultiplier = 1.1;
+  if (config.blockhashReset !== false) config.blockhashReset = true;
+
+  const computeBudgetIndex = {
+    limit: -1,
+    price: -1,
+  };
+
+  transaction.instructions.map((ix, index) => {
+    if (ix.programAddress != COMPUTE_BUDGET_PROGRAM_ADDRESS) return;
+
+    if (isSetComputeLimitInstruction(ix)) {
+      computeBudgetIndex.limit = index;
+    }
+    // else if (isSetComputeUnitPriceInstruction(ix)) {
+    //   computeBudgetIndex.price = index;
+    // }
+  });
+
+  if (computeBudgetIndex.limit < 0 || config.computeUnitLimitReset) {
+    const units = await getComputeUnitEstimateForTransactionMessageFactory({ rpc: config.rpc })(
+      transaction,
+    );
+    debug(`Obtained compute units from simulation: ${units}`, "debug");
+    const ix = getSetComputeUnitLimitInstruction({
+      units: units * config.computeUnitLimitMultiplier,
+    });
+
+    if (computeBudgetIndex.limit < 0) {
+      transaction = appendTransactionMessageInstruction(ix, transaction);
+    } else if (config.computeUnitLimitReset) {
+      const nextInstructions = [...transaction.instructions];
+      nextInstructions.splice(computeBudgetIndex.limit, 1, ix);
+      transaction = Object.freeze({
+        ...transaction,
+        instructions: nextInstructions,
+      } as typeof transaction);
+    }
+  }
+
+  if ("lifetimeConstraint" in transaction == false) {
+    debug("Transaction missing latest blockhash, fetching one.", "debug");
+    const { value: latestBlockhash } = await config.rpc.getLatestBlockhash().send();
+    transaction = setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, transaction);
+  } else {
+    // todo: auto refresh existing latest blockhash
+    // debug("Auto refreshing latest blockhash, fetching a new one.", "debug");
+    // auto refresh will be especially helpful if we simulate multiple compute budget values or make other api calls
+  }
+
+  debug(`Transaction as base64: ${transactionToBase64(transaction)}`);
+
+  return transaction;
+}

--- a/packages/gill/src/core/rpc.ts
+++ b/packages/gill/src/core/rpc.ts
@@ -9,6 +9,7 @@ import {
   CreateSolanaClientArgs,
   CreateSolanaClientResult,
 } from "../types/rpc";
+import { sendAndConfirmTransactionFactory } from "../kit";
 
 export function localnet(putativeString: string): LocalnetUrl {
   return putativeString as LocalnetUrl;
@@ -95,8 +96,12 @@ export function createSolanaClient<TCluster extends ModifiedClusterUrl>({
     rpcSubscriptionsConfig,
   );
 
+  // @ts-ignore
+  const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions });
+
   return {
     rpc,
     rpcSubscriptions,
+    sendAndConfirmTransaction,
   };
 }

--- a/packages/gill/src/kit/send-and-confirm-durable-nonce-transaction.ts
+++ b/packages/gill/src/kit/send-and-confirm-durable-nonce-transaction.ts
@@ -1,3 +1,4 @@
+import type { Signature } from '@solana/keys';
 import type { GetAccountInfoApi, GetSignatureStatusesApi, Rpc, SendTransactionApi } from '@solana/rpc';
 import type { AccountNotificationsApi, RpcSubscriptions, SignatureNotificationsApi } from '@solana/rpc-subscriptions';
 import {
@@ -15,7 +16,7 @@ type SendAndConfirmDurableNonceTransactionFunction = (
         Parameters<typeof sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT>[0],
         'confirmDurableNonceTransaction' | 'rpc' | 'transaction'
     >,
-) => Promise<void>;
+) => Promise<Signature>;
 
 type SendAndConfirmDurableNonceTransactionFactoryConfig<TCluster> = {
     rpc: Rpc<GetAccountInfoApi & GetSignatureStatusesApi & SendTransactionApi> & { '~cluster'?: TCluster };
@@ -60,7 +61,7 @@ export function sendAndConfirmDurableNonceTransactionFactory<
         });
     }
     return async function sendAndConfirmDurableNonceTransaction(transaction, config) {
-        await sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
+        return await sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
             ...config,
             confirmDurableNonceTransaction,
             rpc,

--- a/packages/gill/src/kit/send-and-confirm-transaction.ts
+++ b/packages/gill/src/kit/send-and-confirm-transaction.ts
@@ -1,3 +1,4 @@
+import type { Signature } from '@solana/keys';
 import type { GetEpochInfoApi, GetSignatureStatusesApi, Rpc, SendTransactionApi } from '@solana/rpc';
 import type { RpcSubscriptions, SignatureNotificationsApi, SlotNotificationsApi } from '@solana/rpc-subscriptions';
 import {
@@ -9,13 +10,13 @@ import { FullySignedTransaction, TransactionWithBlockhashLifetime } from '@solan
 
 import { sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT } from './send-transaction-internal';
 
-type SendAndConfirmTransactionWithBlockhashLifetimeFunction = (
+export type SendAndConfirmTransactionWithBlockhashLifetimeFunction = (
     transaction: FullySignedTransaction & TransactionWithBlockhashLifetime,
-    config: Omit<
+    config?: Omit<
         Parameters<typeof sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT>[0],
         'confirmRecentTransaction' | 'rpc' | 'transaction'
     >,
-) => Promise<void>;
+) => Promise<Signature>;
 
 type SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<TCluster> = {
     rpc: Rpc<GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi> & { '~cluster'?: TCluster };
@@ -58,8 +59,9 @@ export function sendAndConfirmTransactionFactory<TCluster extends 'devnet' | 'ma
             getRecentSignatureConfirmationPromise,
         });
     }
-    return async function sendAndConfirmTransaction(transaction, config) {
-        await sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
+
+    return async function sendAndConfirmTransaction(transaction, config = { commitment: "confirmed" }) {
+        return await sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
             ...config,
             confirmRecentTransaction,
             rpc,

--- a/packages/gill/src/kit/send-transaction-internal.ts
+++ b/packages/gill/src/kit/send-transaction-internal.ts
@@ -12,7 +12,7 @@ import {
     TransactionWithBlockhashLifetime,
     TransactionWithDurableNonceLifetime,
 } from '@solana/transactions';
-import { debug, getExplorerLink } from '../core';
+import { debug, getExplorerLink, transactionToBase64 } from '../core';
 
 interface SendAndConfirmDurableNonceTransactionConfig
     extends SendTransactionBaseConfig,
@@ -82,6 +82,7 @@ export async function sendTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
     ...sendTransactionConfig
 }: SendTransactionBaseConfig): Promise<Signature> {
     debug(`Sending transaction: ${getExplorerLink({transaction: getSignatureFromTransaction(transaction)})}`)
+    debug(`Transaction as base64: ${transactionToBase64(transaction)}`, "debug");
     const base64EncodedWireTransaction = getBase64EncodedWireTransaction(transaction);
     return await rpc
         .sendTransaction(base64EncodedWireTransaction, {

--- a/packages/gill/src/programs/compute-budget.ts
+++ b/packages/gill/src/programs/compute-budget.ts
@@ -1,0 +1,38 @@
+import {
+  COMPUTE_BUDGET_PROGRAM_ADDRESS,
+  ComputeBudgetInstruction,
+} from "@solana-program/compute-budget";
+import {
+  IInstruction,
+  IInstructionWithData,
+  isInstructionForProgram,
+  isInstructionWithData,
+} from "@solana/instructions";
+
+/**
+ * Check if a given instruction is a `SetComputeUnitLimit` instruction
+ */
+export function isSetComputeLimitInstruction(
+  instruction: IInstruction,
+): instruction is IInstruction<typeof COMPUTE_BUDGET_PROGRAM_ADDRESS> &
+  IInstructionWithData<Uint8Array> {
+  return (
+    isInstructionForProgram(instruction, COMPUTE_BUDGET_PROGRAM_ADDRESS) &&
+    isInstructionWithData(instruction) &&
+    instruction.data[0] === ComputeBudgetInstruction.SetComputeUnitLimit
+  );
+}
+
+/**
+ * Check if a given instruction is a `SetComputeUnitPrice` instruction
+ */
+export function isSetComputeUnitPriceInstruction(
+  instruction: IInstruction,
+): instruction is IInstruction<typeof COMPUTE_BUDGET_PROGRAM_ADDRESS> &
+  IInstructionWithData<Uint8Array> {
+  return (
+    isInstructionForProgram(instruction, COMPUTE_BUDGET_PROGRAM_ADDRESS) &&
+    isInstructionWithData(instruction) &&
+    instruction.data[0] === ComputeBudgetInstruction.SetComputeUnitPrice
+  );
+}

--- a/packages/gill/src/programs/index.ts
+++ b/packages/gill/src/programs/index.ts
@@ -3,5 +3,7 @@
  */
 
 export * from "@solana-program/system";
-export * from "@solana-program/compute-budget";
 export * from "@solana-program/memo";
+
+export * from "@solana-program/compute-budget";
+export * from "./compute-budget";

--- a/packages/gill/src/types/index.ts
+++ b/packages/gill/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from "./rpc";
 export * from "./explorer";
+export * from "./transactions";
 
 export type Simplify<T> = {
   [K in keyof T]: T[K];

--- a/packages/gill/src/types/rpc.ts
+++ b/packages/gill/src/types/rpc.ts
@@ -10,6 +10,7 @@ import type {
   SolanaRpcSubscriptionsApi,
 } from "@solana/rpc-subscriptions";
 import type { DevnetUrl, MainnetUrl, TestnetUrl } from "@solana/rpc-types";
+import { SendAndConfirmTransactionWithBlockhashLifetimeFunction } from "../kit";
 
 /** Solana cluster moniker */
 export type SolanaClusterMoniker = "mainnet" | "devnet" | "testnet" | "localnet";
@@ -32,9 +33,17 @@ export type CreateSolanaClientArgs<
 };
 
 export type CreateSolanaClientResult<TClusterUrl extends ModifiedClusterUrl | string = string> = {
+  /** Used to make RPC calls to your RPC provider */
   rpc: RpcFromTransport<
     SolanaRpcApiFromTransport<RpcTransportFromClusterUrl<TClusterUrl>>,
     RpcTransportFromClusterUrl<TClusterUrl>
   >;
+  /** Used to make RPC websocket calls to your RPC provider */
   rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi> & TClusterUrl;
+  /**
+   * Send and confirm a transaction to the network
+   *
+   * Default commitment level: `confirmed`
+   */
+  sendAndConfirmTransaction: SendAndConfirmTransactionWithBlockhashLifetimeFunction;
 };


### PR DESCRIPTION
### Summary of Changes

added an easier way to initialize the `sendAndConfirmTransaction` function by returning it with the `createSolanaClient`