### PR TITLE
setting compute budget in `createTransaction`

### DIFF
--- a/.changeset/silly-chicken-switch.md
+++ b/.changeset/silly-chicken-switch.md
@@ -1,0 +1,5 @@
+---
+"gill": minor
+---
+
+easily add compute budget instructions when creating a transaction

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
 
 Quickly create a Solana transaction:
 
+> Note: The `feePayer` can be either an `Address` or `TransactionSigner`.
+
 ```typescript
 import { createTransaction } from "gill";
 
@@ -80,6 +82,9 @@ const transaction = createTransaction({
   version,
   feePayer,
   instructions,
+  // the compute budget values are HIGHLY recommend to be set in order to maximize your transaction landing rate
+  // computeUnitLimit: number,
+  // computeUnitPrice: number,
 });
 ```
 
@@ -95,10 +100,29 @@ const transaction = createTransaction({
   feePayer,
   instructions,
   latestBlockhash,
+  // the compute budget values are HIGHLY recommend to be set in order to maximize your transaction landing rate
+  // computeUnitLimit: number,
+  // computeUnitPrice: number,
 });
 ```
 
-The `feePayer` can be either an `Address` or `TransactionSigner`.
+To create a transaction while setting the latest blockhash:
+
+```typescript
+import { createTransaction } from "gill";
+
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+const transaction = createTransaction({
+  version,
+  feePayer,
+  instructions,
+  latestBlockhash,
+  // the compute budget values are HIGHLY recommend to be set in order to maximize your transaction landing rate
+  // computeUnitLimit: number,
+  // computeUnitPrice: number,
+});
+```
 
 ### Signing transactions
 

--- a/packages/gill/README.md
+++ b/packages/gill/README.md
@@ -73,6 +73,8 @@ const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
 
 Quickly create a Solana transaction:
 
+> Note: The `feePayer` can be either an `Address` or `TransactionSigner`.
+
 ```typescript
 import { createTransaction } from "gill";
 
@@ -80,6 +82,9 @@ const transaction = createTransaction({
   version,
   feePayer,
   instructions,
+  // the compute budget values are HIGHLY recommend to be set in order to maximize your transaction landing rate
+  // computeUnitLimit: number,
+  // computeUnitPrice: number,
 });
 ```
 
@@ -95,10 +100,29 @@ const transaction = createTransaction({
   feePayer,
   instructions,
   latestBlockhash,
+  // the compute budget values are HIGHLY recommend to be set in order to maximize your transaction landing rate
+  // computeUnitLimit: number,
+  // computeUnitPrice: number,
 });
 ```
 
-The `feePayer` can be either an `Address` or `TransactionSigner`.
+To create a transaction while setting the latest blockhash:
+
+```typescript
+import { createTransaction } from "gill";
+
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+const transaction = createTransaction({
+  version,
+  feePayer,
+  instructions,
+  latestBlockhash,
+  // the compute budget values are HIGHLY recommend to be set in order to maximize your transaction landing rate
+  // computeUnitLimit: number,
+  // computeUnitPrice: number,
+});
+```
 
 ### Signing transactions
 

--- a/packages/gill/src/__tests__/transactions.ts
+++ b/packages/gill/src/__tests__/transactions.ts
@@ -75,6 +75,7 @@ describe("createTransaction", () => {
     });
 
     assert.equal(tx.version, "legacy");
+    assert.equal(tx.instructions.length, 1);
     assert.equal(hasSetComputeLimitInstruction(tx), true);
     assert.equal(hasSetComputeUnitPriceInstruction(tx), false);
   });
@@ -88,11 +89,12 @@ describe("createTransaction", () => {
     });
 
     assert.equal(tx.version, "legacy");
+    assert.equal(tx.instructions.length, 1);
     assert.equal(hasSetComputeLimitInstruction(tx), false);
     assert.equal(hasSetComputeUnitPriceInstruction(tx), true);
   });
 
-  test("create a legacy transaction with a both compute budget instructions", () => {
+  test("create a legacy transaction with both compute budget instructions", () => {
     const tx = createTransaction({
       version: "legacy",
       feePayer: signer.address,
@@ -102,6 +104,7 @@ describe("createTransaction", () => {
     });
 
     assert.equal(tx.version, "legacy");
+    assert.equal(tx.instructions.length, 2);
     assert.equal(hasSetComputeLimitInstruction(tx), true);
     assert.equal(hasSetComputeUnitPriceInstruction(tx), true);
   });
@@ -136,6 +139,7 @@ describe("createTransaction", () => {
     });
 
     assert.equal(tx.version, 0);
+    assert.equal(tx.instructions.length, 1);
     assert.equal(hasSetComputeLimitInstruction(tx), true);
     assert.equal(hasSetComputeUnitPriceInstruction(tx), false);
   });
@@ -149,11 +153,12 @@ describe("createTransaction", () => {
     });
 
     assert.equal(tx.version, 0);
+    assert.equal(tx.instructions.length, 1);
     assert.equal(hasSetComputeLimitInstruction(tx), false);
     assert.equal(hasSetComputeUnitPriceInstruction(tx), true);
   });
 
-  test("create a version 0 transaction with a both compute budget instructions", () => {
+  test("create a version 0 transaction with both compute budget instructions", () => {
     const tx = createTransaction({
       version: 0,
       feePayer: signer.address,
@@ -163,6 +168,7 @@ describe("createTransaction", () => {
     });
 
     assert.equal(tx.version, 0);
+    assert.equal(tx.instructions.length, 2);
     assert.equal(hasSetComputeLimitInstruction(tx), true);
     assert.equal(hasSetComputeUnitPriceInstruction(tx), true);
   });

--- a/packages/gill/src/__tests__/transactions.ts
+++ b/packages/gill/src/__tests__/transactions.ts
@@ -4,6 +4,7 @@ import { generateKeyPairSigner, isKeyPairSigner, KeyPairSigner } from "@solana/s
 import { blockhash } from "@solana/rpc-types";
 
 import { createTransaction } from "../core";
+import { hasSetComputeLimitInstruction, hasSetComputeUnitPriceInstruction } from "../programs";
 
 describe("createTransaction", () => {
   let signer: KeyPairSigner;
@@ -28,6 +29,9 @@ describe("createTransaction", () => {
     assert.equal(isKeyPairSigner(tx.feePayer), true);
     assert.equal(tx.instructions.length, 0);
     assert.equal(Object.hasOwn(tx, "lifetimeConstraint"), true);
+    assert.equal(tx.lifetimeConstraint.blockhash, "GK1nopeF3P8J46dGqq4KfaEWopZU7K65F6CKQXuUdr3z");
+    assert.equal(hasSetComputeUnitPriceInstruction(tx), false);
+    assert.equal(hasSetComputeLimitInstruction(tx), false);
   });
 
   test("create a version 0 transaction with a signer as the feePayer", () => {
@@ -42,6 +46,8 @@ describe("createTransaction", () => {
     assert.equal(isKeyPairSigner(tx.feePayer), true);
     assert.equal(tx.instructions.length, 0);
     assert.equal(Object.hasOwn(tx, "lifetimeConstraint"), false);
+    assert.equal(hasSetComputeUnitPriceInstruction(tx), false);
+    assert.equal(hasSetComputeLimitInstruction(tx), false);
   });
 
   test("create a legacy transaction with an `Address` as the feePayer", () => {
@@ -56,6 +62,48 @@ describe("createTransaction", () => {
     assert.equal(isKeyPairSigner(tx.feePayer), false);
     assert.equal(tx.instructions.length, 0);
     assert.equal(Object.hasOwn(tx, "lifetimeConstraint"), false);
+    assert.equal(hasSetComputeUnitPriceInstruction(tx), false);
+    assert.equal(hasSetComputeLimitInstruction(tx), false);
+  });
+
+  test("create a legacy transaction with a compute unit limit instruction", () => {
+    const tx = createTransaction({
+      version: "legacy",
+      feePayer: signer.address,
+      instructions: [],
+      computeUnitLimit: 0,
+    });
+
+    assert.equal(tx.version, "legacy");
+    assert.equal(hasSetComputeLimitInstruction(tx), true);
+    assert.equal(hasSetComputeUnitPriceInstruction(tx), false);
+  });
+
+  test("create a legacy transaction with a compute unit price instruction", () => {
+    const tx = createTransaction({
+      version: "legacy",
+      feePayer: signer.address,
+      instructions: [],
+      computeUnitPrice: 0,
+    });
+
+    assert.equal(tx.version, "legacy");
+    assert.equal(hasSetComputeLimitInstruction(tx), false);
+    assert.equal(hasSetComputeUnitPriceInstruction(tx), true);
+  });
+
+  test("create a legacy transaction with a both compute budget instructions", () => {
+    const tx = createTransaction({
+      version: "legacy",
+      feePayer: signer.address,
+      instructions: [],
+      computeUnitLimit: 0,
+      computeUnitPrice: 0,
+    });
+
+    assert.equal(tx.version, "legacy");
+    assert.equal(hasSetComputeLimitInstruction(tx), true);
+    assert.equal(hasSetComputeUnitPriceInstruction(tx), true);
   });
 
   test("create a version 0 transaction with an `Address` as the feePayer", () => {
@@ -74,5 +122,48 @@ describe("createTransaction", () => {
     assert.equal(isKeyPairSigner(tx.feePayer), false);
     assert.equal(tx.instructions.length, 0);
     assert.equal(Object.hasOwn(tx, "lifetimeConstraint"), true);
+    assert.equal(tx.lifetimeConstraint.blockhash, "GK1nopeF3P8J46dGqq4KfaEWopZU7K65F6CKQXuUdr3z");
+    assert.equal(hasSetComputeUnitPriceInstruction(tx), false);
+    assert.equal(hasSetComputeLimitInstruction(tx), false);
+  });
+
+  test("create a version 0 transaction with a compute unit limit instruction", () => {
+    const tx = createTransaction({
+      version: 0,
+      feePayer: signer.address,
+      instructions: [],
+      computeUnitLimit: 0,
+    });
+
+    assert.equal(tx.version, 0);
+    assert.equal(hasSetComputeLimitInstruction(tx), true);
+    assert.equal(hasSetComputeUnitPriceInstruction(tx), false);
+  });
+
+  test("create a version 0 transaction with a compute unit price instruction", () => {
+    const tx = createTransaction({
+      version: 0,
+      feePayer: signer.address,
+      instructions: [],
+      computeUnitPrice: 0,
+    });
+
+    assert.equal(tx.version, 0);
+    assert.equal(hasSetComputeLimitInstruction(tx), false);
+    assert.equal(hasSetComputeUnitPriceInstruction(tx), true);
+  });
+
+  test("create a version 0 transaction with a both compute budget instructions", () => {
+    const tx = createTransaction({
+      version: 0,
+      feePayer: signer.address,
+      instructions: [],
+      computeUnitLimit: 0,
+      computeUnitPrice: 0,
+    });
+
+    assert.equal(tx.version, 0);
+    assert.equal(hasSetComputeLimitInstruction(tx), true);
+    assert.equal(hasSetComputeUnitPriceInstruction(tx), true);
   });
 });

--- a/packages/gill/src/__typetests__/transactions.ts
+++ b/packages/gill/src/__typetests__/transactions.ts
@@ -27,6 +27,8 @@ import { createTransaction } from "../core";
       version: "legacy",
       feePayer: feePayer,
       instructions: [ix],
+      computeUnitLimit: 0,
+      computeUnitPrice: 0,
     }) satisfies BaseTransactionMessage<"legacy"> & ITransactionMessageWithFeePayer;
 
     createTransaction({
@@ -76,6 +78,8 @@ import { createTransaction } from "../core";
       version: 0,
       feePayer: feePayer,
       instructions: [ix],
+      computeUnitLimit: 0,
+      computeUnitPrice: 0,
     }) satisfies BaseTransactionMessage<0> & ITransactionMessageWithFeePayer;
 
     createTransaction({

--- a/packages/gill/src/programs/compute-budget.ts
+++ b/packages/gill/src/programs/compute-budget.ts
@@ -8,6 +8,7 @@ import {
   isInstructionForProgram,
   isInstructionWithData,
 } from "@solana/instructions";
+import { TransactionMessage } from "@solana/transaction-messages";
 
 /**
  * Check if a given instruction is a `SetComputeUnitLimit` instruction
@@ -24,6 +25,13 @@ export function isSetComputeLimitInstruction(
 }
 
 /**
+ * Check if a given transaction contains a `SetComputeUnitLimit` instruction
+ */
+export function hasSetComputeLimitInstruction(tx: TransactionMessage): boolean {
+  return tx.instructions.filter(isSetComputeLimitInstruction).length == 1;
+}
+
+/**
  * Check if a given instruction is a `SetComputeUnitPrice` instruction
  */
 export function isSetComputeUnitPriceInstruction(
@@ -35,4 +43,11 @@ export function isSetComputeUnitPriceInstruction(
     isInstructionWithData(instruction) &&
     instruction.data[0] === ComputeBudgetInstruction.SetComputeUnitPrice
   );
+}
+
+/**
+ * Check if a given transaction contains a `SetComputeUnitPrice` instruction
+ */
+export function hasSetComputeUnitPriceInstruction(tx: TransactionMessage): boolean {
+  return tx.instructions.filter(isSetComputeUnitPriceInstruction).length == 1;
 }

--- a/packages/gill/src/types/transactions.ts
+++ b/packages/gill/src/types/transactions.ts
@@ -31,11 +31,11 @@ export type CreateTransactionInput<
    * accepted for execution on the Solana network
    * */
   latestBlockhash?: TLifetimeConstraint;
+  /** Compute unit limit value to set on this transaction */
+  computeUnitLimit?: number | bigint;
+  /** Compute unit price (in micro-lamports) to set on this transaction */
+  computeUnitPrice?: number | bigint;
 };
-
-// TLifetimeConstraint extends
-//     | TransactionMessageWithBlockhashLifetime["lifetimeConstraint"]
-//     | {} = {}
 
 export type FullTransaction<
   TVersion extends TransactionVersion,


### PR DESCRIPTION
### Summary of Changes

add support for setting the `computeUnitLimit` and `computeUnitPrice` instruction values inside of `createTransaction` to easily set them when creating transactions