### PR TITLE
ci: ignore docs for bundlemon

### DIFF
--- a/.github/workflows/bundlesize.yml
+++ b/.github/workflows/bundlesize.yml
@@ -3,8 +3,12 @@ name: Compare bundle size
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     types: [synchronize, opened, reopened]
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   build:


### PR DESCRIPTION
### Problem

even for docs only changes, all the github workflows run. this is unnecessary 

### Summary of Changes

ignore docs for the bundlemon check
