### PR TITLE
docs : added migration guide from @solana/kit to gill

### DIFF
--- a/docs/content/docs/getting-started/migration.mdx
+++ b/docs/content/docs/getting-started/migration.mdx
@@ -1,29 +1,158 @@
 ---
-title: "Migration Guide"
-description: "A simple guide to migrating from @solana/kit to gill."
+title: Migration Guide
+
+description: The Complete Guide to Migrating from @solana/kit to Gill
 ---
 
-## Why migrate?
+This guide provides a comprehensive walkthrough for migrating your Solana application from
+`@solana/kit` to `gill`. Since **gill** is built directly on top of **@solana/kit**, it's fully
+compatible, making the switch seamless and highly beneficial.
 
-**gill** is a powerful toolkit built directly on top of
-[`@solana/kit`](https://www.npmjs.com/package/@solana/kit). It provides all the same tree-shakable,
-performant, and composable primitives that Kit offers, but adds a layer of carefully crafted
-abstractions designed to drastically improve the developer experience.
+By the end of this guide, you will have replaced the old packages, refactored your code to take
+advantage of Gill's powerful abstractions, and learned how to build a modern, reactive frontend with
+`@gillsdk/react`.
 
-By upgrading, you can eliminate significant amounts of boilerplate code for common tasks like
-setting up connections, loading keypairs, and building transactions. This allows you to write
-cleaner, more readable code and focus on your application's core logic, not the low-level logics.
-Since `gill` is a superset of `kit`, you can migrate incrementally, adopting `gill`'s helpers at
-your own pace.
+## Why Migrate to Gill?
 
----
+Before diving in, it's helpful to understand the benefits. Migrating to Gill allows you to:
 
-## Connections
+- **Reduce Boilerplate**: Gill provides higher-level abstractions for common tasks, significantly
+  cutting down on verbose code.
+- **Simplify Dependencies**: Gill bundles clients for the most common Solana Program Library (SPL)
+  programs, so you can remove multiple `@solana-program/*` packages from your project.
+- **Maintain Flexibility**: While offering simple abstractions, Gill still exposes the same
+  low-level primitives as `@solana/kit`, giving you granular control.
+- **Improve Code Readability**: With simplified functions, your application's business logic becomes
+  clearer and easier to maintain.
 
-The `createSolanaClient` function replaces the manual setup of RPC, subscriptions, and the
-transaction sending function.
+## Part 1: Core Migration Steps
 
-**@solana/kit**
+The migration involves four main steps: installing `gill`, understanding its import structure,
+replacing your existing imports, and then uninstalling the old packages.
+
+### 1. Install Gill
+
+First, add the `gill` package to your project using your preferred package manager.
+
+```package-install
+gill
+```
+
+### 2. Understanding Gill's Import Paths
+
+Before you start replacing imports, it's important to know that Gill organizes its functionality
+into distinct paths. This improves code organization and ensures you only bundle what you need for a
+specific environment.
+
+- `import { ... } from "gill"`: This is the **main entry point** for all core functionalities that
+  work in any JavaScript environment. You'll use this for functions like `createSolanaClient`,
+  `createTransaction`, and `generateKeyPairSigner`.
+- `import { ... } from "gill/programs"`: This path is dedicated to **Solana Program clients**. When
+  you need instructions or constants related to the System Program, Token Program (Token-2022), Memo
+  Program, etc., you'll import them from here.
+- `import { ... } from "gill/node"`: This path contains **server-only utilities** designed for
+  runtimes like Node.js and Bun. These functions often interact with the file system or environment
+  variables, such as `loadKeypairSignerFromFile`.
+
+### 3. Replace `@solana/kit` and SPL Program Imports
+
+Now, with an understanding of the import paths, you can update your code.
+
+**Step A: Replace Core Imports**  
+Find all instances where you import from `@solana/kit` and change the path to `gill`.
+
+**Before:**
+
+```ts
+import { createSolanaRpc, createTransactionMessage } from "@solana/kit";
+```
+
+**After:**
+
+```ts
+import { createSolanaRpc, createTransactionMessage } from "gill";
+```
+
+**Step B: Replace Program Imports**  
+Next, consolidate your SPL program imports to use the `gill/programs` path. This replaces individual
+Solana Program Library (SPL) packages like `@solana-program/compute-budget` or
+`@solana-program/memo`.
+
+**Before:**
+
+```ts
+import { getSetComputeUnitLimitInstruction } from "@solana-program/compute-budget";
+import { getAddMemoInstruction } from "@solana-program/memo";
+```
+
+**After:**
+
+```ts
+import { getSetComputeUnitLimitInstruction, getAddMemoInstruction } from "gill/programs";
+```
+
+### 4. Uninstall Old Packages
+
+Finally, clean up your `package.json` by uninstalling `@solana/kit` and the individual
+`@solana-program/*` packages that you've replaced.
+
+```bash
+npm uninstall @solana/kit @solana-program/compute-budget @solana-program/memo
+# and any other SPL packages you replaced
+```
+
+Your application is now fully migrated to use Gill's core library!
+
+## Part 2: Upgrading Your Solana Workflow
+
+Migrating to Gill is more than a syntax change; it's a shift in how you approach common Solana
+development tasks. Instead of manual, multi-step processes, you'll adopt a more direct and
+declarative workflow. Here’s a practical breakdown of how your approach will change for specific
+tasks.
+
+### For Managing Dependencies:
+
+- **@solana/kit**: Your `package.json` would typically include `@solana/kit` plus numerous
+  individual `@solana-program/*` packages for SPL functionality (like Token, Memo, etc.).
+- **gill**: Your dependencies become unified. You primarily rely on the single `gill` package,
+  accessing core functionality and common SPL program clients through its distinct entry points
+  (`gill`, `gill/programs`).
+
+### For Debugging:
+
+- **@solana/kit**: Debugging often involved manual `console.log` statements, inspecting raw
+  transaction objects, and manually constructing explorer links to check on failed transactions.
+- **gill**: Debugging is now an integrated feature. You can enable **Debug Mode** to get automatic,
+  context-rich logs, including pre-formatted Solana Explorer links that are printed to the console
+  the moment you send a transaction.
+
+### From Manual Orchestration to High-Level Abstractions:
+
+- **@solana/kit**: Manually handling each step of a workflow—writing boilerplate to load keypairs,
+  setting up separate RPC clients, chaining functions with `pipe()` to build transactions, and
+  crafting individual SPL token instructions.
+
+- **gill**: Using single, high-level functions that abstract entire workflows. One-line helpers load
+  keypairs, `createSolanaClient` instantly provides a full connection, and "Transaction Builders"
+  assemble complex, multi-instruction transactions (like token transfers with automatic ATA
+  creation) in one go.
+
+### For On-Chain Data Calculation:
+
+- **@solana/kit**: It was common to rely on RPC network calls to fetch data that is technically
+  calculable on the client-side, such as the minimum balance required for rent exemption
+  (`rpc.getMinimumBalanceForRentExemption()`), which introduces network latency.
+- **gill**: The workflow shifts to using synchronous, offline utility functions provided by Gill
+  whenever possible. You can now instantly compute the rent exemption amount locally, leading to
+  faster application logic and reduced reliance on RPC calls.
+
+## Part 3: Refactoring with Gill's Abstractions
+
+After completing the core migration, you can refactor your code to leverage Gill's simplifications.
+
+### Creating a Solana RPC Connection
+
+**@solana/kit:**
 
 ```ts
 import {
@@ -34,287 +163,150 @@ import {
 } from "@solana/kit";
 
 const rpc = createSolanaRpc(devnet("https://api.devnet.solana.com"));
-const rpcSubscriptions = createSolanaRpcSubscriptions(devnet("wss://api.devnet.solana.com"));
-const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({
-  rpc,
-  rpcSubscriptions,
-});
 ```
 
-**gill**
+**gill:**
 
 ```ts
 import { createSolanaClient } from "gill";
+
 const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient({
   urlOrMoniker: "devnet",
 });
 ```
 
----
+**Note**: Ensure the `createSolanaClient` call is robust by handling potential network errors.
+Consider using a try-catch or a fallback URL if the `devnet` connection fails.
 
-## Loading a Keypair without the Fuss
+For more, refer to this section: [gill vs @solana/kit](https://www.gillsdk.com/docs/compare/kit)
 
-`@solana/kit` is unopinionated about how you manage keypairs, meaning you have to write your own
-logic for loading them from files or environment variables. For server-side applications, `gill`
-provides a set of convenient, Node.js-specific helpers to handle this common task.
+## Part 4: Building a Reactive Frontend with @gillsdk/react
 
-**@solana/kit**
+Now that your core logic is migrated, the next step is to build a reactive user interface.
+`@gillsdk/react` is a companion package to `gill`, providing React hooks for interacting with Solana
+on-chain data. It requires `gill` as a peer dependency and is built on top of the powerful
+**TanStack Query** library, offering sophisticated features like automatic caching, background
+refetching, and robust error handling.
 
-```ts
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { resolve } from "node:path";
-import { createKeyPairFromBytes } from "@solana/kit";
+### Getting Started: A Quick Guide
 
-const keypairPath = resolve(homedir(), ".config", "solana", "id.json");
-const secretKey = new Uint8Array(JSON.parse(readFileSync(keypairPath, "utf-8")));
-const signer = await createKeyPairFromBytes(secretKey);
+**1. Install Dependencies**
+
+Install `@gillsdk/react` along with its required peer dependencies.
+
+```bash
+npm install gill @gillsdk/react @tanstack/react-query
 ```
 
-**gill**
+**2. Set Up QueryClientProvider and SolanaProvider**
 
-```ts
-import { loadKeypairSignerFromFile } from "gill/node";
-// Defaults to the Solana CLI's default keypair path.
-const signer = await loadKeypairSignerFromFile();
+Since `@gillsdk/react` relies on TanStack Query, you need to wrap your app with
+`QueryClientProvider` and `SolanaProvider`. When using Next.js App Router or other React Server
+Component (RSC) frameworks, create a client-side wrapper marked with the `"use client"` directive.
 
-// Or specify a path.
-const signer = await loadKeypairSignerFromFile("/path/to/my/keypair.json");
-```
+```jsx
+// src/providers/solana-provider.jsx
+"use client";
+import { createSolanaClient } from "gill";
+import { SolanaProvider } from "@gillsdk/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
----
+const queryClient = new QueryClient();
+const solanaClient = createSolanaClient({ urlOrMoniker: "devnet" });
 
-## Calculating Rent without a Network Call
-
-A common task is to find the minimum lamports needed for an account to be rent-exempt. With
-'@solana/kit', you have to make a network call. gill has a built-in helper that calculates this
-instantly without any network latency. This is faster and saves on RPC credits.
-
-**@solana/kit**
-
-```ts
-// This requires an RPC connection and a network call
-const { value: rent } = await rpc.getMinimumBalanceForRentExemption(50n).send();
-// rent will be 1238880n
-```
-
-**gill**
-
-```ts
-import { getMinimumBalanceForRentExemption } from "gill";
-
-// This is a synchronous, instant calculation. No `await`, no `rpc` needed.
-const rent = getMinimumBalanceForRentExemption(50);
-// rent will be 1238880n
-```
-
----
-
-## Building Transactions
-
-### Where did all the factory functions and pipe() go?
-
-In `@solana/kit`, setting up a connection and building a transaction requires wiring together
-multiple factory functions and composing helpers with the `pipe()` utility. This provides maximum
-composability but can be verbose for everyday tasks.
-
-`gill` simplifies this by providing higher-level helper functions that handle the common-case setup
-for you, without sacrificing the ability to access the low-level primitives when you need them.
-
-Similarly, the `createTransaction` function replaces the `pipe()` flow with a single, descriptive
-configuration object.
-
-**@solana/kit**
-
-```ts
-import {
-  pipe,
-  createTransactionMessage,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  appendTransactionMessageInstructions,
-} from "@solana/kit";
-import { getTransferSolInstruction } from "@solana-program/system";
-
-// Assume `payer`, `destinationAddress`, and `latestBlockhash` are already defined
-
-// Create the instruction first
-const transferInstruction = getTransferSolInstruction({
-  source: payer.address,
-  destination: destinationAddress,
-  amount: 1_000_000_000, // 1 SOL
-});
-
-// use that variable in the pipe
-const transactionMessage = pipe(
-  createTransactionMessage({ version: 0 }),
-  (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-  (tx) => appendTransactionMessageInstructions([transferInstruction], tx),
-);
-```
-
-**gill**
-
-```ts
-import { createTransaction } from "gill";
-import { getTransferSolInstruction } from "gill/programs";
-
-// Assume `payer`, `destinationAddress`, and `latestBlockhash` are already defined
-
-//  Create the instruction first
-const transferInstruction = getTransferSolInstruction({
-  source: payer.address,
-  destination: destinationAddress,
-  amount: 1_000_000_000, // 1 SOL
-});
-
-// Now, use that variable in the transaction object
-const transaction = createTransaction({
-  version: 0,
-  feePayer: payer,
-  instructions: [transferInstruction],
-  latestBlockhash,
-});
-```
-
-You can still access and use the low-level `pipe` and composer functions from `gill` if you need
-custom behavior, as `gill` re-exports everything from `@solana/kit`.
-
-## Even Simpler: Transaction Builders
-
-For very common multi-instruction tasks, like creating a token with metadata or transferring tokens,
-`gill` goes a step further by providing high-level **Transaction Builders**. These functions
-abstract away even more complexity, such as deriving associated token accounts and setting optimized
-compute unit limits. `@solana/kit` does not have an equivalent for this level of abstraction.
-
-For example, building a transaction to transfer SPL tokens.
-
-**@solana/kit**
-
-```ts
-import {
-  pipe,
-  createTransactionMessage,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  appendTransactionMessageInstructions,
-} from "@solana/kit";
-import {
-  getAssociatedTokenAccountAddress, // Correct function name
-  getCreateAssociatedTokenAccountInstruction, // Correct function name
-  getTransferInstruction,
-} from "@solana-program/token";
-
-// Assume we already have:
-// rpc: Rpc client
-// payer: Signer
-// mint: Address
-// destinationOwner: Address
-// amount: bigint
-// latestBlockhash: Blockhash
-
-const instructions = [];
-
-// 1. Derive source and destination addresses
-const sourceAta = await getAssociatedTokenAccountAddress(mint, payer.address);
-const destinationAta = await getAssociatedTokenAccountAddress(mint, destinationOwner);
-
-// 2. Check if the destination account exists
-const destinationAtaInfo = await rpc.getAccountInfo(destinationAta).send();
-
-// 3. Conditionally add the instruction to create the destination account
-if (destinationAtaInfo.value === null) {
-  instructions.push(
-    getCreateAssociatedTokenAccountInstruction({
-      payer,
-      associatedToken: destinationAta,
-      owner: destinationOwner,
-      mint,
-    }),
+export function SolanaProviderClient({ children }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <SolanaProvider client={solanaClient}>{children}</SolanaProvider>
+    </QueryClientProvider>
   );
 }
-
-// 4. Add the transfer instruction
-instructions.push(
-  getTransferInstruction({
-    source: sourceAta,
-    destination: destinationAta,
-    owner: payer,
-    amount,
-  }),
-);
-
-// 5. Build the transaction
-const txMessage = pipe(
-  createTransactionMessage({ version: 0 }),
-  (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-  (tx) => appendTransactionMessageInstructions(instructions, tx),
-);
 ```
 
-**gill**
+Then, use this wrapper in your root layout:
 
-```ts
-import { buildTransferTokensTransaction } from "gill/programs/token";
+```jsx
+// src/app/layout.jsx
+import { SolanaProviderClient } from "@/providers/solana-provider";
 
-const transferTx = await buildTransferTokensTransaction({
-  feePayer: signer,
-  latestBlockhash,
-  mint: mintAddress,
-  authority: signer,
-  amount: 1000,
-  destination: destinationWalletAddress,
-});
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>
+        <SolanaProviderClient>{children}</SolanaProviderClient>
+      </body>
+    </html>
+  );
+}
 ```
 
-The transaction builder automatically handles the creation of the associated token account if it
-doesn't exist, bundles the necessary instructions, and sets a recommended compute limit.
+**3. Use the Hooks in Your Components**
 
----
+You can now use any of the available hooks to fetch data. Remember to add `"use client"` to any
+component that uses these hooks when working with RSC frameworks.
 
-## Simplified Explorer Links
+```jsx
+// src/components/WalletBalance.jsx
+"use client";
+import { lamportsToSol } from "gill";
+import { useBalance } from "@gillsdk/react";
 
-While you can always build explorer links yourself, gill provides a simple helper function that
-handles it for you, preventing typos and working across different clusters.
+export function WalletBalance({ address }) {
+  const { data: balance, isLoading, isError } = useBalance({ address });
 
-**@solana/kit**
+  if (isLoading) return <div>Loading balance...</div>;
+  if (isError) return <div>Error fetching balance.</div>;
 
-```ts
-const signature = getSignatureFromTransaction(signedTransaction);
-const link = `https://explorer.solana.com/tx/${signature}?cluster=devnet`;
+  return (
+    <div>
+      <p>Balance: {lamportsToSol(balance)} SOL</p>
+    </div>
+  );
+}
 ```
 
-**gill**
+### Available Hooks
 
-```ts
-import { getExplorerLink } from "gill";
+`@gillsdk/react` organizes its hooks into logical categories:
 
-const signature = getSignatureFromTransaction(signedTransaction);
-const link = getExplorerLink({ transaction: signature, cluster: "devnet" });
-```
+#### Client Management Hooks
 
----
+These hooks are for accessing and managing the core Solana client connection established by your
+`<SolanaProvider>`.
 
-## Easy Transaction Debugging
+- `useSolanaClient`
+- `useUpdateSolanaClient`
 
-'@solana/kit'has no built-in equivalent. You would have to write all this logging logic yourself,
-manually grabbing the signature and constructing the links or base64 strings every time.
-Troubleshooting failed transactions can be difficult. gill has a built-in debug mode that
-automatically logs helpful information.you can also use custom debugging in gill using
-isDebugEnabled() & debug()
+#### Data Fetching Hooks
 
-[refer this doc for more details](https://www.gillsdk.com/docs/debug-mode)
+These are the workhorses of the library, designed to fetch and manage the state of on-chain data.
 
----
+- `useAccount`
+- `useBalance`
+- `useLatestBlockhash`
+- `useProgramAccounts`
+- `useSignatureStatuses`
+- `useSignaturesForAddress`
+- `useTokenAccount`
+- `useTokenMint`
 
-## Closing words
+#### Transaction Hooks (Coming Soon)
 
-Upgrading from `@solana/kit` to `gill` is a low-friction process designed to enhance your
-productivity. Since `gill` is a superset of `kit`, there is no complex compatibility layer needed.
+Hooks to simplify sending and simulating transactions are planned for a future release. In the
+meantime, use `sendAndConfirmTransaction` from `gill` for transaction operations.
 
-You can start by simply replacing all imports from `@solana/kit` with `gill`—your existing code will
-continue to work. From there, you can incrementally refactor your project to adopt `gill`'s
-convenient helpers and builders, cleaning up boilerplate and simplifying your codebase at your own
-pace.
+## Part 5: Validating Your Migration
+
+After migrating, verify your application works as expected:
+
+1. **Run Your Tests**: Ensure your existing test suite passes with the new `gill` imports.
+2. **Test Transactions**: Send a test transaction (e.g., a memo transaction) to confirm that
+   `createTransaction` and `sendAndConfirmTransaction` work correctly.
+3. **Check Frontend**: If using `@gillsdk/react`, verify that hooks like `useBalance` return
+   expected data.
+4. **Enable Debug Mode**: Use Gill's Debug Mode to inspect transaction logs and Solana Explorer
+   links for any issues.
+
+By following this guide, you have not only updated your dependencies but also modernized your entire
+Solana development workflow. You're now equipped to build more robust, readable, and efficient dApps
+with the gill .


### PR DESCRIPTION
### Problem

add guide page that demonstrates the simple process of migrating from @solana/kit to gill

we already have a [gill vs @solana/kit comparison guide](https://gill.site/docs/compare/kit), but its not the same as a migration guide

### Summary of Changes

- Added a new **Migration Guide** page for `@solana/kit → gill`.
- Documented equivalent flows with examples 
- Highlighted key improvements and simplified steps with `gill`.

took reference from -
https://www.solanakit.com/docs/upgrade-guide



Fixes #200 