### PR TITLE
feat: implement useAirdrop hook with tests and types

### DIFF
--- a/packages/react/src/__tests__/airdrop.test.ts
+++ b/packages/react/src/__tests__/airdrop.test.ts
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { useAirdrop } from "../hooks/airdrop";
+import { useAirdrop } from "../hooks/airdrop.js";
 
 // Mock React Query and client hook
 

--- a/packages/react/src/__typeset__/airdrop.ts
+++ b/packages/react/src/__typeset__/airdrop.ts
@@ -1,5 +1,5 @@
 import { Address, Signature, type Lamports } from "gill";
-import { useAirdrop } from "../hooks";
+import { useAirdrop } from "../hooks/airdrop.js";
 
 // [DESCRIBE] useAirdrop
 {

--- a/packages/react/src/hooks/airdrop.ts
+++ b/packages/react/src/hooks/airdrop.ts
@@ -2,7 +2,7 @@
 
 import { useMutation } from "@tanstack/react-query";
 import type { Address, Commitment, Lamports, Signature } from "gill";
-import { useSolanaClient } from "./client";
+import { useSolanaClient } from "./client.js";
 
 type AirdropConfig = {
   /**


### PR DESCRIPTION
### Problem

The React hooks library lacks mutation hooks for write operations. Currently, all hooks are focused on data fetching (read operations) like `useAccount`, `useBalance`, etc. Developers need a way to request SOL airdrops on development networks for testing and development workflows.

### Summary of Changes

- Add `useAirdrop` hook that uses TanStack Query mutations to request SOL airdrops
- Includes mainnet protection with helpful error messages
- Supports both `number` and `bigint` lamport amounts with automatic conversion
- Comprehensive test coverage with unit tests and type tests
- Auto-converts numbers to `Lamports` type for RPC compatibility