### PR TITLE
feat: add subscription to use balance hook

### DIFF
--- a/packages/react/src/hooks/balance.ts
+++ b/packages/react/src/hooks/balance.ts
@@ -1,7 +1,8 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { Address, GetBalanceApi, Simplify } from "gill";
+import { useEffect } from "react";
 
 import { GILL_HOOK_CLIENT_KEY } from "../const.js";
 import { useSolanaClient } from "./client.js";
@@ -15,6 +16,10 @@ type UseBalanceInput<TConfig extends RpcConfig = RpcConfig> = GillUseRpcHook<TCo
    * Address of the account to get the balance of
    */
   address: Address | string;
+  /**
+   * Whether to subscribe to account changes and update the balance.
+   */
+  subscribe?: boolean;
 };
 
 /**
@@ -26,18 +31,48 @@ export function useBalance<TConfig extends RpcConfig = RpcConfig>({
   config,
   abortSignal,
   address,
+  subscribe = false,
 }: UseBalanceInput<TConfig>) {
-  const { rpc, urlOrMoniker } = useSolanaClient();
+  const { rpc, rpcSubscriptions, urlOrMoniker } = useSolanaClient();
+  const queryKey = [GILL_HOOK_CLIENT_KEY, urlOrMoniker, "getBalance", address];
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!subscribe || !address) {
+      return;
+    }
+
+    const controller = new AbortController();
+    const signal = AbortSignal.any([controller.signal, abortSignal].filter(Boolean) as AbortSignal[]);
+
+    const subscribeFn = async () => {
+      const accountNotifications = await rpcSubscriptions
+        .accountNotifications(address as Address)
+        .subscribe({ abortSignal: signal });
+
+      for await (const notification of accountNotifications) {
+        queryClient.setQueryData(queryKey, notification.value.lamports);
+      }
+    };
+
+    void subscribeFn();
+
+    return () => {
+      controller.abort();
+    };
+  }, [subscribe, address, abortSignal, queryKey, queryClient, rpcSubscriptions]);
+
   const { data, ...rest } = useQuery({
-    networkMode: "offlineFirst",
     ...options,
     enabled: (options?.enabled ?? true) && !!address,
+    networkMode: "offlineFirst",
     queryFn: async () => {
       const { value } = await rpc.getBalance(address as Address, config).send({ abortSignal });
       return value;
     },
-    queryKey: [GILL_HOOK_CLIENT_KEY, urlOrMoniker, "getBalance", address],
+    queryKey,
   });
+
   return {
     ...rest,
     balance: data as UseBalanceResponse,


### PR DESCRIPTION
### Problem

Balance changes are fetched rather than subscribed to with the RPC.

### Summary of Changes

Adds a `subscribe` prop to the `useBalance` hook that will subscribe to the account and update the lamports when a notification is received 

Related #121