### PR TITLE
docs(react): fix useAccount example for staleTime/cacheTime

### DIFF
--- a/docs/content/docs/react/hooks/data-fetching.mdx
+++ b/docs/content/docs/react/hooks/data-fetching.mdx
@@ -490,8 +490,10 @@ const { balance } = useBalance({
 ```tsx
 const { account } = useAccount({
   address,
-  staleTime: 30000, // Consider data fresh for 30 seconds
-  cacheTime: 300000, // Keep in cache for 5 minutes
+  options: {
+    staleTime: 30000, // Consider data fresh for 30 seconds
+    cacheTime: 300000, // Keep in cache for 5 minutes
+  },
 });
 ```
 


### PR DESCRIPTION
### Problem

  The useAccount hook documentation in the React section had an incorrect code example for setting staleTime and
  cacheTime. The example showed these as top-level properties, but they should be nested inside an options object to be
  correctly applied. This could lead to incorrect usage and unexpected caching behavior for users following the
  documentation.


### Summary of Changes
  This change corrects the code example for the useAccount hook in the data-fetching.mdx documentation file. It moves
  the staleTime and cacheTime properties into a nested options object, making the example consistent with the hook's
  actual API
