### PR TITLE
docs(react): rename cacheTime to gcTime and clarify semantics

### DIFF
--- a/docs/content/docs/react/examples.mdx
+++ b/docs/content/docs/react/examples.mdx
@@ -133,7 +133,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 60 * 1000, // 1 minute
-      cacheTime: 10 * 60 * 1000, // 10 minutes
+      gcTime: 10 * 60 * 1000, // 10 minutes
     },
   },
 });

--- a/docs/content/docs/react/getting-started.mdx
+++ b/docs/content/docs/react/getting-started.mdx
@@ -259,7 +259,7 @@ If you're hitting rate limits:
 
 1. Switch from public endpoints to a dedicated RPC provider
 2. Implement request batching and caching strategies
-3. Consider using the `staleTime` and `cacheTime` options in hooks
+3. Consider using the `staleTime` and `gcTime` options in hooks
 
 ### Bundle Size
 

--- a/docs/content/docs/react/hooks/data-fetching.mdx
+++ b/docs/content/docs/react/hooks/data-fetching.mdx
@@ -492,7 +492,7 @@ const { account } = useAccount({
   address,
   options: {
     staleTime: 30000, // Consider data fresh for 30 seconds
-    cacheTime: 300000, // Keep in cache for 5 minutes
+    gcTime: 300000, // Time to garbage-collect unused queries (5 minutes)
   },
 });
 ```

--- a/docs/content/docs/react/hooks/index.mdx
+++ b/docs/content/docs/react/hooks/index.mdx
@@ -62,8 +62,8 @@ interface HookOptions {
   // Time in milliseconds before data is considered stale
   staleTime?: number;
 
-  // Time in milliseconds to keep data in cache
-  cacheTime?: number;
+  // Time in milliseconds after a query becomes unused to garbage-collect it
+  gcTime?: number;
 
   // Whether to enable the query
   enabled?: boolean;


### PR DESCRIPTION
### Problem
Rename cacheTime to gcTime in TanStack Query v5.
Reference: https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5#rename-cachetime-to-gctime

### Summary of Changes
Renamed references of cacheTime to gcTime across React docs to better convey semantics.
