### PR TITLE
Added dRPC to Popular RPC providers section

### DIFF
--- a/docs/content/docs/react/getting-started.mdx
+++ b/docs/content/docs/react/getting-started.mdx
@@ -183,6 +183,7 @@ const client = createSolanaClient({
 - [Alchemy](https://alchemy.com)
 - [Triton](https://triton.one)
 - [Syndica](https://syndica.io)
+- [dRPC NodeCloud](https://drpc.org/chainlist/solana-mainnet-rpc)
 
 ### Multiple Clients
 


### PR DESCRIPTION

### Problem

dRPC Nodecloud not in list of popular RPC providers.

### Summary of Changes

Added dRPC NodeCloud to the list of popular RPC providers. Instead of using the website link, I used the direct link to dRPC's Solana page, which includes the public endpoints.

Fixes #