### PR TITLE
fix: fixed version for config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,7 +13,7 @@
     "@gillsdk/vue", "@gillsdk/svelte", 
     "@gillsdk/tsconfig", "@gillsdk/build-scripts", "@gillsdk/test-config"
   ],
-  "fixed": [["@gillsdk/!({build-scripts,test-*,tsconfig})"]],
+  "fixed": [["@gillsdk/!({build-scripts,config-*,test-*,tsconfig})"]],
   "linked": [],
   "updateInternalDependencies": "patch"
 }


### PR DESCRIPTION
### Problem

The local `config-eslint` should not have its version changed on version bumps

### Summary of Changes

Marked all local config packages as fixed