### PR TITLE
fix(gill): move @gillsdk/config-eslint to devDependencies

### DIFF
--- a/.changeset/brown-crabs-film.md
+++ b/.changeset/brown-crabs-film.md
@@ -1,0 +1,5 @@
+---
+"gill": minor
+---
+
+move @gillsdk/config-eslint to devDependencies

--- a/packages/gill/package.json
+++ b/packages/gill/package.json
@@ -110,7 +110,6 @@
     "node": ">=20.18.0"
   },
   "dependencies": {
-    "@gillsdk/config-eslint": "workspace:*",
     "@solana-program/address-lookup-table": "^0.9.0",
     "@solana-program/compute-budget": "^0.10.0",
     "@solana-program/system": "^0.9.0",
@@ -119,6 +118,9 @@
     "@solana/codecs": "^5.0.0",
     "@solana/kit": "^5.0.0",
     "@solana/transaction-confirmation": "^5.0.0"
+  },
+  "devDependencies": {
+    "@gillsdk/config-eslint": "workspace:*"
   },
   "peerDependencies": {
     "typescript": ">=5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,9 +188,6 @@ importers:
 
   packages/gill:
     dependencies:
-      '@gillsdk/config-eslint':
-        specifier: workspace:*
-        version: link:../config-eslint
       '@solana-program/address-lookup-table':
         specifier: ^0.9.0
         version: 0.9.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))
@@ -218,6 +215,10 @@ importers:
       typescript:
         specifier: '>=5'
         version: 5.9.2
+    devDependencies:
+      '@gillsdk/config-eslint':
+        specifier: workspace:*
+        version: link:../config-eslint
 
   packages/react:
     dependencies:


### PR DESCRIPTION
### Problem

The `@gillsdk/config-eslint` package is listed in the `dependencies` 

### Summary of Changes

Move `@gillsdk/config-eslint` to the `devDependencies`

Fixes #332 